### PR TITLE
Making GenerateKeys and PeekRowKey virtual

### DIFF
--- a/src/ElCamino.AspNetCore.Identity.AzureTable/Model/IdentityRole.cs
+++ b/src/ElCamino.AspNetCore.Identity.AzureTable/Model/IdentityRole.cs
@@ -24,7 +24,7 @@ public class IdentityRole : IdentityRole<string, IdentityUserRole>, IGenerateKey
         /// Generates Row and Id keys.
         /// Partition key is equal to the UserId
         /// </summary>
-        public void GenerateKeys()
+        public virtual void GenerateKeys()
         {
             RowKey = PeekRowKey();
             PartitionKey = KeyHelper.GeneratePartitionKeyIdentityRole(Name);
@@ -35,7 +35,7 @@ public class IdentityRole : IdentityRole<string, IdentityUserRole>, IGenerateKey
         /// Generates the RowKey without setting it on the object.
         /// </summary>
         /// <returns></returns>
-        public string PeekRowKey()
+        public virtual string PeekRowKey()
         {
             return KeyHelper.GenerateRowKeyIdentityRole(Name);
         }

--- a/src/ElCamino.AspNetCore.Identity.AzureTable/Model/IdentityUser.cs
+++ b/src/ElCamino.AspNetCore.Identity.AzureTable/Model/IdentityUser.cs
@@ -37,7 +37,7 @@ public class IdentityUser : IdentityUser<string, IdentityUserLogin, IdentityUser
         /// Generates Row, Partition and Id keys.
         /// All are the same in this case
         /// </summary>
-        public void GenerateKeys()
+        public virtual void GenerateKeys()
         {
             Id = PeekRowKey();
             PartitionKey = Id;
@@ -49,7 +49,7 @@ public class IdentityUser : IdentityUser<string, IdentityUserLogin, IdentityUser
         /// In this case, just returns a key based on username
         /// </summary>
         /// <returns></returns>
-        public string PeekRowKey()
+        public virtual string PeekRowKey()
         {
             return KeyHelper.GenerateRowKeyUserName(UserName);
         }

--- a/src/ElCamino.AspNetCore.Identity.AzureTable/Model/IdentityUserClaim.cs
+++ b/src/ElCamino.AspNetCore.Identity.AzureTable/Model/IdentityUserClaim.cs
@@ -24,7 +24,7 @@ public class IdentityUserClaim : IdentityUserClaim<string>, IGenerateKeys
         /// Generates Row and Id keys.
         /// Partition key is equal to the UserId
         /// </summary>
-        public void GenerateKeys()
+        public virtual void GenerateKeys()
         {
             Id = Guid.NewGuid().ToString();
             RowKey = PeekRowKey();
@@ -35,7 +35,7 @@ public class IdentityUserClaim : IdentityUserClaim<string>, IGenerateKeys
         /// Generates the RowKey without setting it on the object.
         /// </summary>
         /// <returns></returns>
-        public string PeekRowKey()
+        public virtual string PeekRowKey()
         {
             return KeyHelper.GenerateRowKeyIdentityUserClaim(ClaimType, ClaimValue);
         }

--- a/src/ElCamino.AspNetCore.Identity.AzureTable/Model/IdentityUserLogin.cs
+++ b/src/ElCamino.AspNetCore.Identity.AzureTable/Model/IdentityUserLogin.cs
@@ -25,7 +25,7 @@ public class IdentityUserLogin : IdentityUserLogin<string>, IGenerateKeys
         /// Generates Row and Id keys.
         /// Partition key is equal to the UserId
         /// </summary>
-        public void GenerateKeys()
+        public virtual void GenerateKeys()
         {
             Id = Guid.NewGuid().ToString();
             RowKey = PeekRowKey();
@@ -38,7 +38,7 @@ public class IdentityUserLogin : IdentityUserLogin<string>, IGenerateKeys
         /// Generates the RowKey without setting it on the object.
         /// </summary>
         /// <returns></returns>
-        public string PeekRowKey()
+        public virtual string PeekRowKey()
         {
             return KeyHelper.GenerateRowKeyIdentityUserLogin(LoginProvider, ProviderKey);
         }

--- a/src/ElCamino.AspNetCore.Identity.AzureTable/Model/IdentityUserRole.cs
+++ b/src/ElCamino.AspNetCore.Identity.AzureTable/Model/IdentityUserRole.cs
@@ -24,7 +24,7 @@ public class IdentityUserRole : IdentityUserRole<string>, IGenerateKeys
         /// Generates Row and Id keys.
         /// Partition key is equal to the UserId
         /// </summary>
-        public void GenerateKeys()
+        public virtual void GenerateKeys()
         {
             Id = Guid.NewGuid().ToString();
             RowKey = PeekRowKey();
@@ -35,7 +35,7 @@ public class IdentityUserRole : IdentityUserRole<string>, IGenerateKeys
         /// Generates the RowKey without setting it on the object.
         /// </summary>
         /// <returns></returns>
-        public string PeekRowKey()
+        public virtual string PeekRowKey()
         {
             return KeyHelper.GenerateRowKeyIdentityUserRole(RoleName);
         }

--- a/src/ElCamino.AspNetCore.Identity.AzureTable/UserStore.cs
+++ b/src/ElCamino.AspNetCore.Identity.AzureTable/UserStore.cs
@@ -33,7 +33,7 @@ namespace ElCamino.AspNet.Identity.AzureTable
 		}
 
 		/// <summary>
-		/// Simple table queries allowed. Projections are only allowed for TUser types. 
+		/// Simple table queries allowed. Projections are only allowed for TUser types.
 		/// </summary>
 		public override IQueryable<TUser> Users
 		{
@@ -65,7 +65,7 @@ namespace ElCamino.AspNet.Identity.AzureTable
 		, IUserLockoutStore<TUser, TKey>
 		, IUserStore<TUser, TKey>
 		, IDisposable
-		where TUser : IdentityUser<TKey, TUserLogin, TUserRole, TUserClaim>, new()
+		where TUser : IdentityUser<TKey, TUserLogin, TUserRole, TUserClaim>, IGenerateKeys, new()
 		where TRole : IdentityRole<TKey, TUserRole>, new()
 		where TKey : IEquatable<TKey>
 		where TUserLogin : IdentityUserLogin<TKey>, new()
@@ -544,7 +544,7 @@ namespace ElCamino.AspNet.Identity.AzureTable
 				user.ETag = vUser.ETag;
 				user.Timestamp = vUser.Timestamp;
 
-				//Roles                            
+				//Roles
 				foreach (var log in userResults.Where(u => u.RowKey.StartsWith(Constants.RowKeyConstants.PreFixIdentityUserRole)
 					 && u.PartitionKey.Equals(userId)))
 				{
@@ -955,7 +955,7 @@ namespace ElCamino.AspNet.Identity.AzureTable
 
 			List<Task> tasks = new List<Task>(2);
 
-			string userNameKey = KeyHelper.GenerateRowKeyUserName(user.UserName);
+			string userNameKey = user.PeekRowKey();
 			if (user.Id.ToString() != userNameKey)
 			{
 				tasks.Add(Task.FromResult<TUser>(ChangeUserName(user)));


### PR DESCRIPTION
Thanks for the implementation. I'd need to customize the keys for the table entities. For example, user key should be user.Id instead of user.Username and so on.
Making GenerateKeys and PeekRowKey virtual ideally solves my problem.