### PR TITLE
Added ability to create immutable User ids regarding issue #35

### DIFF
--- a/src/ElCamino.AspNetCore.Identity.AzureTable/Model/IdentityConfiguration.cs
+++ b/src/ElCamino.AspNetCore.Identity.AzureTable/Model/IdentityConfiguration.cs
@@ -15,5 +15,12 @@ namespace ElCamino.AspNetCore.Identity.AzureTable.Model
 
         [JsonProperty("locationMode")]
         public string LocationMode { get; set; }
+
+        /// <summary>
+        /// If true, then the user ids will never be updated, if false it will change when you change the user name.
+        /// Default : false
+        /// </summary>
+        [JsonProperty("enableImmutableUserId")]
+        public bool EnableImmutableUserId { get; set; }
     }
 }

--- a/tests/ElCamino.AspNetCore.Identity.AzureTable.Tests/Fixtures/BaseFixture.partial.cs
+++ b/tests/ElCamino.AspNetCore.Identity.AzureTable.Tests/Fixtures/BaseFixture.partial.cs
@@ -71,7 +71,13 @@ namespace ElCamino.Web.Identity.AzureTable.Tests.Fixtures
 
         public TContext GetContext()
         {
-            return Activator.CreateInstance(typeof(TContext), new object[1] { GetConfig() }) as TContext;
+            return GetContext(GetConfig());
+        }
+
+        public TContext GetContext(IdentityConfiguration config)
+        {
+            return Activator.CreateInstance(typeof(TContext), new object[1] {GetConfig()}) as TContext;
+
         }
 
         public RoleStore<TRole> CreateRoleStore()
@@ -133,12 +139,12 @@ namespace ElCamino.Web.Identity.AzureTable.Tests.Fixtures
 
         public TUserStore CreateUserStore()
         {
-            return CreateUserStore(GetContext());
+            return CreateUserStore(GetContext(),GetConfig());
         }
 
-        public TUserStore CreateUserStore(TContext context)
+        public TUserStore CreateUserStore(TContext context,IdentityConfiguration config)
         {
-            var userStore = Activator.CreateInstance(typeof(TUserStore), new object[1] { context }) as TUserStore;
+            var userStore = Activator.CreateInstance(typeof(TUserStore), new object[2] { context,config }) as TUserStore;
 
             return userStore;
         }

--- a/tests/ElCamino.AspNetCore.Identity.AzureTable.Tests/UserStoreTests.cs
+++ b/tests/ElCamino.AspNetCore.Identity.AzureTable.Tests/UserStoreTests.cs
@@ -198,7 +198,7 @@ namespace ElCamino.AspNetCore.Identity.AzureTable.Tests
         {
             Assert.Throws<ArgumentNullException>(() => 
             {
-                new UserStore<ApplicationUser, IdentityRole, IdentityCloudContext>(null);
+                new UserStore<ApplicationUser, IdentityRole, IdentityCloudContext>(null,null);
             });
         }
     }

--- a/tests/ElCamino.AspNetCore.Identity.AzureTable.Tests/UserStoreV2Tests.cs
+++ b/tests/ElCamino.AspNetCore.Identity.AzureTable.Tests/UserStoreV2Tests.cs
@@ -11,6 +11,7 @@ using Microsoft.AspNetCore.Builder;
 using Xunit;
 using Xunit.Abstractions;
 using ElCamino.AspNetCore.Identity.AzureTable;
+using ElCamino.AspNetCore.Identity.AzureTable.Model;
 using IdentityUser = ElCamino.AspNetCore.Identity.AzureTable.Model.IdentityUser;
 using IdentityRole = ElCamino.AspNetCore.Identity.AzureTable.Model.IdentityRole;
 using ElCamino.Web.Identity.AzureTable.Tests.ModelTests;
@@ -199,7 +200,7 @@ namespace ElCamino.AspNetCore.Identity.AzureTable.Tests
         {
             Assert.Throws<ArgumentNullException>(() =>
             {
-                new UserStoreV2<ApplicationUserV2, IdentityRole, IdentityCloudContext>(null);
+                new UserStoreV2<ApplicationUserV2, IdentityRole, IdentityCloudContext>(null,null);
             });
         }
 
@@ -276,5 +277,46 @@ namespace ElCamino.AspNetCore.Identity.AzureTable.Tests
         }
 
         #endregion
+
+
+        [Fact(DisplayName = "UserIdNotChangedIfImmutableIdSetUp")]
+        [Trait("IdentityCore.Azure.UserStoreV2.Properties", "")]
+
+        public async Task UserIdNotChangedIfImmutableIdSetUp()
+        {
+            var config = userFixture.GetConfig();
+            config.EnableImmutableUserId = true;
+            var userStore = userFixture.CreateUserStore(userFixture.GetContext(config),config);
+
+            var user = GenTestUser();
+            await userStore.CreateAsync(user);
+
+            var idBefore = user.Id;
+            var pkBefore = user.PartitionKey;
+            var rkBefore = user.RowKey;
+
+            user.UserName += "changed";
+            await userStore.UpdateAsync(user);
+
+            Assert.Equal(idBefore,user.Id);
+            Assert.Equal(pkBefore,user.PartitionKey);
+            Assert.Equal(rkBefore,user.RowKey);
+
+        }
+
+        [Fact(DisplayName = "CanFindByNameIfImmutableIdSetUp")]
+        [Trait("IdentityCore.Azure.UserStoreV2.Properties", "")]
+
+        public async Task CanFindByNameIfImmutableIdSetUp()
+        {
+
+        }
+
+        [Fact(DisplayName = "CanFindByIdIfImmutableIdSetUp")]
+        [Trait("IdentityCore.Azure.UserStoreV2.Properties", "")]
+
+        public async Task CanFindByIdIfImmutableIdSetUp()
+        {
+        }
     }
 }


### PR DESCRIPTION
I updated the following things :
- Added a configuration for enabling this feature (false by default)
- CreateAsync fills an index with username <=> user id
- UpdateAsync doesn't update the Id if the user name changes
- FindByName uses the index beforequerying the user details
- Unit testing 

Because the rest of the code (roles/claims) uses user.id I guess I don't have to do more tests.

What do you think ? 

So far the user id is still based on the user name, a second step would be to add a feature for generating ids : autoincrement, guid, hash ...