### PR TITLE
Use new hashing functionality for .NET 6

### DIFF
--- a/src/ElCamino.AspNetCore.Identity.AzureTable/Helpers/BaseKeyHelper.cs
+++ b/src/ElCamino.AspNetCore.Identity.AzureTable/Helpers/BaseKeyHelper.cs
@@ -151,6 +151,9 @@ namespace ElCamino.AspNetCore.Identity.AzureTable.Helpers
         {
             // Convert the input string to a byte array and compute the hash. 
             byte[] data = shaHash.ComputeHash(encoding.GetBytes(input));
+#if NET6_0_OR_GREATER
+            return Convert.ToHexString(data).ToLowerInvariant();
+#else
             Debug.WriteLine(string.Format("Key Size before hash: {0} bytes", encoding.GetBytes(input).Length));
 
             // Create a new StringBuilder to collect the bytes 
@@ -167,6 +170,7 @@ namespace ElCamino.AspNetCore.Identity.AzureTable.Helpers
 
             // Return the hexadecimal string. 
             return sBuilder.ToString();
+#endif
         }
     }
 }

--- a/src/ElCamino.AspNetCore.Identity.AzureTable/Helpers/DefaultKeyHelper.cs
+++ b/src/ElCamino.AspNetCore.Identity.AzureTable/Helpers/DefaultKeyHelper.cs
@@ -1,5 +1,6 @@
 ﻿// MIT License Copyright 2020 (c) David Melendez. All rights reserved. See License.txt in the project root for license information.
 
+using System;
 using System.Security.Cryptography;
 using System.Text;
 
@@ -11,8 +12,17 @@ namespace ElCamino.AspNetCore.Identity.AzureTable.Helpers
         {
             if (input != null)
             {
+                var encoding = Encoding.Unicode;
+#if NET6_0_OR_GREATER
+                // We can elide the SHA1 allocation if this isn't a derived type
+                if (GetType() == typeof(DefaultKeyHelper))
+                {
+                    byte[] data = SHA1.HashData(encoding.GetBytes(input));
+                    return Convert.ToHexString(data).ToLowerInvariant();
+                }
+#endif
                 using SHA1 sha = SHA1.Create();
-                return GetHash(sha, input, Encoding.Unicode, 40);
+                return GetHash(sha, input, encoding, 40);
             }
             return null;
         }

--- a/src/ElCamino.AspNetCore.Identity.AzureTable/Helpers/SHA256KeyHelper.cs
+++ b/src/ElCamino.AspNetCore.Identity.AzureTable/Helpers/SHA256KeyHelper.cs
@@ -1,5 +1,6 @@
 ﻿// MIT License Copyright 2020 (c) David Melendez. All rights reserved. See License.txt in the project root for license information.
 
+using System;
 using System.Security.Cryptography;
 using System.Text;
 
@@ -14,8 +15,17 @@ namespace ElCamino.AspNetCore.Identity.AzureTable.Helpers
         {
             if (input != null)
             {
+                var encoding = Encoding.UTF8;
+#if NET6_0_OR_GREATER
+                // We can elide the SHA256 allocation if this isn't a derived type
+                if (GetType() == typeof(SHA256KeyHelper))
+                {
+                    byte[] data = SHA256.HashData(encoding.GetBytes(input));
+                    return Convert.ToHexString(data).ToLowerInvariant();
+                }
+#endif
                 using SHA256 sha = SHA256.Create();
-                return GetHash(sha, input, Encoding.UTF8, 64);
+                return GetHash(sha, input, encoding, 64);
             }
             return null;
         }

--- a/src/ElCamino.Azure.Data.Tables/TableQuery.cs
+++ b/src/ElCamino.Azure.Data.Tables/TableQuery.cs
@@ -69,7 +69,11 @@ namespace Azure.Data.Tables
             string operation,
             byte[] givenValue)
         {
+            string hash;
 
+#if NET6_0_OR_GREATER
+            hash = Convert.ToHexString(givenValue).ToLowerInvariant();
+#else
             StringBuilder sb = new StringBuilder();
 
             foreach (byte b in givenValue)
@@ -77,7 +81,10 @@ namespace Azure.Data.Tables
                 sb.AppendFormat("{0:x2}", b);
             }
 
-            return GenerateFilterCondition(propertyName, operation, sb.ToString(), EdmType.Binary);
+            hash = sb.ToString();
+#endif
+
+            return GenerateFilterCondition(propertyName, operation, hash, EdmType.Binary);
         }
 
         /// <summary>


### PR DESCRIPTION
When targeting `net6.0`, use new hashing related functionality to improve the performance and reduce the amount of code (modulo the hash define).
