### PR TITLE
Use IdentityUserClaim<T>.ToClaim() to prevent data not being returned from table

### DIFF
--- a/src/ElCamino.AspNetCore.Identity.AzureTable/RoleStore.cs
+++ b/src/ElCamino.AspNetCore.Identity.AzureTable/RoleStore.cs
@@ -180,7 +180,7 @@ namespace ElCamino.AspNetCore.Identity.AzureTable
             return
 
                 (await _roleTable.QueryAsync<TRoleClaim>(filter, cancellationToken: cancellationToken).ToListAsync(cancellationToken).ConfigureAwait(false))
-                .Select(w => new Claim(w.ClaimType, w.ClaimValue))
+                .Select(w => w.ToClaim())
                 .ToList() as IList<Claim>;
         }
 

--- a/src/ElCamino.AspNetCore.Identity.AzureTable/UserOnlyStore.cs
+++ b/src/ElCamino.AspNetCore.Identity.AzureTable/UserOnlyStore.cs
@@ -388,7 +388,7 @@ namespace ElCamino.AspNetCore.Identity.AzureTable
                 //1.7 Claim rowkey migration 
                 if (_keyHelper.GenerateRowKeyIdentityUserClaim(tclaim.ClaimType, tclaim.ClaimValue) == tclaim.RowKey)
                 {
-                    rClaims.Add(new Claim(tclaim.ClaimType, tclaim.ClaimValue));
+                    rClaims.Add(tclaim.ToClaim());
                 }
             }
 


### PR DESCRIPTION
Use the [`IdentityUserClaim<T>.ToClaim()` method](https://github.com/dotnet/aspnetcore/blob/b39a258cbce1b16ee98679ef7d2ddc2e09040a6b/src/Identity/Extensions.Stores/src/IdentityUserClaim.cs#L39-L42) to create `Claim` instances from claim entities so that overridden behaviours are observed.

Otherwise if a user creates a custom claim type, for example so they can store the claim issuer and claim value type, this information is lost when reading from the store as the additional data is not copied to the `Claim` instances created by the user store as only the Type and Value are used.

An example of such a type is below.

```csharp
public sealed class ApplicationUserClaim : IdentityUserClaim
{
    public string? ClaimIssuer { get; set; }

    public string? ClaimValueType { get; set; }

    public override void InitializeFromClaim(Claim claim)
    {
        base.InitializeFromClaim(claim);

        ClaimIssuer = claim.Issuer;
        ClaimValueType = claim.ValueType;
    }

    public override Claim ToClaim()
        => new(ClaimType!, ClaimValue!, ClaimValueType, ClaimIssuer);
}
```

After this change, additional properties added to the claim entity are correctly materialised from the table.

The behaviour for the out-of-the-box implementation is unchanged as the default `ToClaim()` implementation does the same as the store code did before the change.
