### PR TITLE
Allow TokenCredentials to be passed in Config

### DIFF
--- a/src/ElCamino.AspNetCore.Identity.AzureTable.Model/IdentityConfiguration.cs
+++ b/src/ElCamino.AspNetCore.Identity.AzureTable.Model/IdentityConfiguration.cs
@@ -1,6 +1,9 @@
 ﻿// MIT License Copyright 2020 (c) David Melendez. All rights reserved. See License.txt in the project root for license information.
 
 
+using System;
+using Azure.Core;
+
 namespace ElCamino.AspNetCore.Identity.AzureTable.Model
 {
     /// <summary>
@@ -32,6 +35,9 @@ namespace ElCamino.AspNetCore.Identity.AzureTable.Model
         /// Optional, default value is AspNetRoles
         /// </summary>
         public string? RoleTableName { get; set; }
+
+        public Uri? StorageConnectionUri { get; set; }
+        public TokenCredential? TokenCredential { get; set; }
 
     }
 }

--- a/src/ElCamino.AspNetCore.Identity.AzureTable/IdentityCloudContext.cs
+++ b/src/ElCamino.AspNetCore.Identity.AzureTable/IdentityCloudContext.cs
@@ -30,17 +30,42 @@ namespace ElCamino.AspNetCore.Identity.AzureTable
             }
 #endif
 
-            _client = new TableServiceClient(config.StorageConnectionString);
-            _indexTable = _client.GetTableClient(FormatTableNameWithPrefix(config!.TablePrefix, !string.IsNullOrWhiteSpace(config!.IndexTableName) ? config!.IndexTableName! : TableConstants.TableNames.IndexTable));
-            _roleTable = _client.GetTableClient(FormatTableNameWithPrefix(config!.TablePrefix, !string.IsNullOrWhiteSpace(config!.RoleTableName) ? config!.RoleTableName! : TableConstants.TableNames.RolesTable));
-            _userTable = _client.GetTableClient(FormatTableNameWithPrefix(config!.TablePrefix, !string.IsNullOrWhiteSpace(config!.UserTableName) ? config!.UserTableName! : TableConstants.TableNames.UsersTable));
+            if (string.IsNullOrEmpty(config.StorageConnectionString) && config.StorageConnectionUri == null)
+            {
+                throw new ArgumentNullException(nameof(config.StorageConnectionString), "Either StorageConnectionString or StorageConnectionUri are required");
+            }
+            else if (!string.IsNullOrEmpty(config.StorageConnectionString))
+            {
+                _client = new TableServiceClient(config.StorageConnectionString);
+
+                if (config.TokenCredential != null)
+                {
+                    //If we've been passed a TokenCredential we can use that instead of the credentials in the connection string
+                    _client = new TableServiceClient(_client.Uri, config.TokenCredential);
+                }
+            }
+            else // if (config.StorageConnectionUri != null)
+            {
+                if (config.TokenCredential == null)
+                {
+                    throw new ArgumentNullException(nameof(config.TokenCredential), "TokenCredential is required when Uri is specified");
+                }
+                else
+                {
+                    _client = new TableServiceClient(config.StorageConnectionUri, config.TokenCredential);
+                }
+            }
+
+            _indexTable = _client.GetTableClient(FormatTableNameWithPrefix(config.TablePrefix, !string.IsNullOrWhiteSpace(config.IndexTableName) ? config.IndexTableName : TableConstants.TableNames.IndexTable));
+            _roleTable = _client.GetTableClient(FormatTableNameWithPrefix(config.TablePrefix, !string.IsNullOrWhiteSpace(config.RoleTableName) ? config.RoleTableName : TableConstants.TableNames.RolesTable));
+            _userTable = _client.GetTableClient(FormatTableNameWithPrefix(config.TablePrefix, !string.IsNullOrWhiteSpace(config.UserTableName) ? config.UserTableName : TableConstants.TableNames.UsersTable));
         }
 
         private static string FormatTableNameWithPrefix(string? tablePrefix, string baseTableName)
         {
             if (!string.IsNullOrWhiteSpace(tablePrefix))
             {
-                return string.Format("{0}{1}", tablePrefix!, baseTableName);
+                return string.Format("{0}{1}", tablePrefix, baseTableName);
             }
             return baseTableName;
         }


### PR DESCRIPTION
This change will allow a TokenCredential to be passed in to the configuration of the table client. This will allow [Managed Identities](https://learn.microsoft.com/en-us/azure/storage/tables/authorize-managed-identity) to be used instead of Shared Access Keys.

Please note that currently this change will only work on "public" Azure Clouds (where the subdomain of the table service is `table.core.windows.net`)

Happy to make changes to this as required