### PR TITLE
Rel/9.0

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -61,10 +61,14 @@ dotnet_naming_style.pascal_case_style.capitalization             = pascal_case
 # Use PascalCase for constant fields  
 dotnet_naming_rule.constant_fields_should_be_pascal_case.severity = suggestion
 dotnet_naming_rule.constant_fields_should_be_pascal_case.symbols  = constant_fields
-dotnet_naming_rule.constant_fields_should_be_pascal_case.style    = pascal_case_style
+dotnet_naming_rule.constant_fields_should_be_pascal_case.style = pascal_case_style
 dotnet_naming_symbols.constant_fields.applicable_kinds            = field
 dotnet_naming_symbols.constant_fields.applicable_accessibilities  = *
 dotnet_naming_symbols.constant_fields.required_modifiers          = const
+dotnet_style_prefer_simplified_boolean_expressions = true:suggestion
+dotnet_style_operator_placement_when_wrapping = beginning_of_line
+tab_width = 4
+end_of_line = crlf
 ###############################
 # C# Coding Conventions       #
 ###############################
@@ -131,6 +135,15 @@ csharp_preserve_single_line_blocks = true
 
 # IDE0007: Use implicit type
 dotnet_diagnostic.IDE0007.severity = none
+csharp_using_directive_placement = outside_namespace:silent
+csharp_prefer_simple_using_statement = true:suggestion
+csharp_style_namespace_declarations = block_scoped:silent
+csharp_style_prefer_method_group_conversion = true:silent
+csharp_style_prefer_top_level_statements = true:silent
+csharp_style_prefer_primary_constructors = false:suggestion
+csharp_prefer_system_threading_lock = true:suggestion
+csharp_style_expression_bodied_lambdas = true:silent
+csharp_style_expression_bodied_local_functions = false:silent
 
 [*.vb]
 # Modifier preferences

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -23,14 +23,14 @@ steps:
     script: (Get-Content .\tests\ElCamino.Azure.Data.Tables.Tests\config.json) | Foreach-Object { $_ -replace 'UseDevelopmentStorage=true;', '$(StorageConnection)'} | Set-Content .\tests\ElCamino.Azure.Data.Tables.Tests\config.json
 
 - task: UseDotNet@2
-  displayName: 'Use .Net Core sdk 6.x'
-  inputs:
-    version: 6.x
-
-- task: UseDotNet@2
   displayName: 'Use .Net Core sdk 8.x'
   inputs:
     version: 8.x
+
+- task: UseDotNet@2
+  displayName: 'Use .Net Core sdk 9.x'
+  inputs:
+    version: 9.x
 
 - task: DotNetCoreCLI@2
   displayName: 'dotnet build'

--- a/sample/samplemvccore4/wwwroot/lib/bootstrap/package.json
+++ b/sample/samplemvccore4/wwwroot/lib/bootstrap/package.json
@@ -135,7 +135,7 @@
     "popper.js": "^1.16.0",
     "postcss-cli": "^6.1.3",
     "qunit": "2.9.2",
-    "rollup": "1.26.5",
+    "rollup": "2.79.2",
     "rollup-plugin-babel": "^4.3.3",
     "rollup-plugin-commonjs": "^10.1.0",
     "rollup-plugin-node-resolve": "^5.2.0",

--- a/src/ElCamino.AspNetCore.Identity.AzureTable.Model/ElCamino.AspNetCore.Identity.AzureTable.Model.csproj
+++ b/src/ElCamino.AspNetCore.Identity.AzureTable.Model/ElCamino.AspNetCore.Identity.AzureTable.Model.csproj
@@ -5,7 +5,7 @@
     <Copyright>Copyright ©  David Melendez, MIT License</Copyright>
     <AssemblyTitle>Azure Table Storage Provider for ASP.NET Identity Core Models</AssemblyTitle>
     <Authors>David Melendez</Authors>
-    <TargetFrameworks>netstandard2.0;net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
     <LangVersion>13.0</LangVersion>
     <AssemblyName>ElCamino.AspNetCore.Identity.AzureTable.Model</AssemblyName>
     <AssemblyOriginatorKeyFile>../../tools/key.snk</AssemblyOriginatorKeyFile>

--- a/src/ElCamino.AspNetCore.Identity.AzureTable.Model/ElCamino.AspNetCore.Identity.AzureTable.Model.csproj
+++ b/src/ElCamino.AspNetCore.Identity.AzureTable.Model/ElCamino.AspNetCore.Identity.AzureTable.Model.csproj
@@ -5,8 +5,8 @@
     <Copyright>Copyright ©  David Melendez, MIT License</Copyright>
     <AssemblyTitle>Azure Table Storage Provider for ASP.NET Identity Core Models</AssemblyTitle>
     <Authors>David Melendez</Authors>
-    <TargetFrameworks>netstandard2.0;net6.0;net8.0</TargetFrameworks>
-    <LangVersion>12.0</LangVersion>
+    <TargetFrameworks>netstandard2.0;net8.0;net9.0</TargetFrameworks>
+    <LangVersion>13.0</LangVersion>
     <AssemblyName>ElCamino.AspNetCore.Identity.AzureTable.Model</AssemblyName>
     <AssemblyOriginatorKeyFile>../../tools/key.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
@@ -22,7 +22,7 @@
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/dlmelendez/identityazuretable.git</RepositoryUrl>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
-    <Version>8.0</Version>
+    <Version>9.0</Version>
     <Nullable>enable</Nullable>
     <PackageProjectUrl>https://dlmelendez.github.io/identityazuretable</PackageProjectUrl>
     <!--<DebugType>Full</DebugType>-->
@@ -36,12 +36,12 @@
   <ItemGroup>
     <PackageReference Include="Azure.Data.Tables" Version="12.8.1" />
   </ItemGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net8.0' ">
-    <PackageReference Include="Microsoft.Extensions.Identity.Stores" Version="8.0.0" />
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net9.0' ">
+    <PackageReference Include="Microsoft.Extensions.Identity.Stores" Version="9.0.*" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' != 'net8.0' ">
-    <PackageReference Include="Microsoft.Extensions.Identity.Stores" Version="6.0.24" />
+  <ItemGroup Condition=" '$(TargetFramework)' != 'net9.0' ">
+    <PackageReference Include="Microsoft.Extensions.Identity.Stores" Version="8.0.*" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ElCamino.AspNetCore.Identity.AzureTable.Model/IKeyHelper.cs
+++ b/src/ElCamino.AspNetCore.Identity.AzureTable.Model/IKeyHelper.cs
@@ -224,7 +224,7 @@ namespace ElCamino.AspNetCore.Identity.AzureTable.Model
         /// </summary>
         /// <param name="rowKey"></param>
         /// <returns></returns>
-        string ParsePartitionKeyIdentityRoleFromRowKey(string rowKey);
+        ReadOnlySpan<char> ParsePartitionKeyIdentityRoleFromRowKey(string rowKey);
 
         /// <summary>
         /// Key Version

--- a/src/ElCamino.AspNetCore.Identity.AzureTable.Model/IKeyHelper.cs
+++ b/src/ElCamino.AspNetCore.Identity.AzureTable.Model/IKeyHelper.cs
@@ -171,7 +171,7 @@ namespace ElCamino.AspNetCore.Identity.AzureTable.Model
         /// </summary>
         /// <param name="plainRoleName"></param>
         /// <returns></returns>
-        string GenerateRowKeyIdentityUserRole(string? plainRoleName);
+        ReadOnlySpan<char> GenerateRowKeyIdentityUserRole(string? plainRoleName);
 
         /// <summary>
         /// Generate key for RowKeyIdentityRole

--- a/src/ElCamino.AspNetCore.Identity.AzureTable.Model/IKeyHelper.cs
+++ b/src/ElCamino.AspNetCore.Identity.AzureTable.Model/IKeyHelper.cs
@@ -143,7 +143,7 @@ namespace ElCamino.AspNetCore.Identity.AzureTable.Model
         /// Generate key for UserId
         /// </summary>
         /// <returns></returns>
-        string GenerateUserId();
+        ReadOnlySpan<char> GenerateUserId();
 
         /// <summary>
         /// Generate key for RowKeyUserName

--- a/src/ElCamino.AspNetCore.Identity.AzureTable.Model/IKeyHelper.cs
+++ b/src/ElCamino.AspNetCore.Identity.AzureTable.Model/IKeyHelper.cs
@@ -137,7 +137,7 @@ namespace ElCamino.AspNetCore.Identity.AzureTable.Model
         /// </summary>
         /// <param name="plainEmail"></param>
         /// <returns></returns>
-        string GenerateRowKeyUserEmail(string? plainEmail);
+        ReadOnlySpan<char> GenerateRowKeyUserEmail(string? plainEmail);
 
         /// <summary>
         /// Generate key for UserId

--- a/src/ElCamino.AspNetCore.Identity.AzureTable.Model/IKeyHelper.cs
+++ b/src/ElCamino.AspNetCore.Identity.AzureTable.Model/IKeyHelper.cs
@@ -150,7 +150,7 @@ namespace ElCamino.AspNetCore.Identity.AzureTable.Model
         /// </summary>
         /// <param name="plainUserName"></param>
         /// <returns></returns>
-        string GenerateRowKeyUserName(string? plainUserName);
+        ReadOnlySpan<char> GenerateRowKeyUserName(string? plainUserName);
 
         /// <summary>
         /// Generate key for PartitionKeyUserName

--- a/src/ElCamino.AspNetCore.Identity.AzureTable.Model/IKeyHelper.cs
+++ b/src/ElCamino.AspNetCore.Identity.AzureTable.Model/IKeyHelper.cs
@@ -209,7 +209,7 @@ namespace ElCamino.AspNetCore.Identity.AzureTable.Model
         /// <param name="loginProvider"></param>
         /// <param name="tokenName"></param>
         /// <returns></returns>
-        string GenerateRowKeyIdentityUserToken(string? loginProvider, string? tokenName);
+        ReadOnlySpan<char> GenerateRowKeyIdentityUserToken(string? loginProvider, string? tokenName);
 
         /// <summary>
         /// Generate key for RowKeyIdentityUserLogin

--- a/src/ElCamino.AspNetCore.Identity.AzureTable.Model/IKeyHelper.cs
+++ b/src/ElCamino.AspNetCore.Identity.AzureTable.Model/IKeyHelper.cs
@@ -164,7 +164,7 @@ namespace ElCamino.AspNetCore.Identity.AzureTable.Model
         /// </summary>
         /// <param name="plainUserId"></param>
         /// <returns></returns>
-        string GenerateRowKeyUserId(string? plainUserId);
+        ReadOnlySpan<char> GenerateRowKeyUserId(string? plainUserId);
 
         /// <summary>
         /// Generate key for RowKeyIdentityUserRole

--- a/src/ElCamino.AspNetCore.Identity.AzureTable.Model/IKeyHelper.cs
+++ b/src/ElCamino.AspNetCore.Identity.AzureTable.Model/IKeyHelper.cs
@@ -217,7 +217,7 @@ namespace ElCamino.AspNetCore.Identity.AzureTable.Model
         /// <param name="loginProvider"></param>
         /// <param name="providerKey"></param>
         /// <returns></returns>
-        string GenerateRowKeyIdentityUserLogin(string? loginProvider, string? providerKey);
+        ReadOnlySpan<char> GenerateRowKeyIdentityUserLogin(string? loginProvider, string? providerKey);
 
         /// <summary>
         /// Parse PartitionKey From RowKey for IdentityRole

--- a/src/ElCamino.AspNetCore.Identity.AzureTable.Model/IKeyHelper.cs
+++ b/src/ElCamino.AspNetCore.Identity.AzureTable.Model/IKeyHelper.cs
@@ -178,7 +178,7 @@ namespace ElCamino.AspNetCore.Identity.AzureTable.Model
         /// </summary>
         /// <param name="plainRoleName"></param>
         /// <returns></returns>
-        string GenerateRowKeyIdentityRole(string? plainRoleName);
+        ReadOnlySpan<char> GenerateRowKeyIdentityRole(string? plainRoleName);
 
         /// <summary>
         /// Generate key for PartitionKeyIdentityRole
@@ -201,7 +201,7 @@ namespace ElCamino.AspNetCore.Identity.AzureTable.Model
         /// <param name="claimType"></param>
         /// <param name="claimValue"></param>
         /// <returns></returns>
-        string GenerateRowKeyIdentityRoleClaim(string? claimType, string? claimValue);
+        ReadOnlySpan<char> GenerateRowKeyIdentityRoleClaim(string? claimType, string? claimValue);
 
         /// <summary>
         /// Generate key for RowKeyIdentityUserToken

--- a/src/ElCamino.AspNetCore.Identity.AzureTable.Model/IKeyHelper.cs
+++ b/src/ElCamino.AspNetCore.Identity.AzureTable.Model/IKeyHelper.cs
@@ -185,7 +185,7 @@ namespace ElCamino.AspNetCore.Identity.AzureTable.Model
         /// </summary>
         /// <param name="plainRoleName"></param>
         /// <returns></returns>
-        string GeneratePartitionKeyIdentityRole(string? plainRoleName);
+        ReadOnlySpan<char> GeneratePartitionKeyIdentityRole(string? plainRoleName);
 
         /// <summary>
         /// Generate key for RowKeyIdentityUserClaim

--- a/src/ElCamino.AspNetCore.Identity.AzureTable.Model/IKeyHelper.cs
+++ b/src/ElCamino.AspNetCore.Identity.AzureTable.Model/IKeyHelper.cs
@@ -193,7 +193,7 @@ namespace ElCamino.AspNetCore.Identity.AzureTable.Model
         /// <param name="claimType"></param>
         /// <param name="claimValue"></param>
         /// <returns></returns>
-        string GenerateRowKeyIdentityUserClaim(string? claimType, string? claimValue);
+        ReadOnlySpan<char> GenerateRowKeyIdentityUserClaim(string? claimType, string? claimValue);
 
         /// <summary>
         /// Generate key for RowKeyIdentityRoleClaim

--- a/src/ElCamino.AspNetCore.Identity.AzureTable.Model/IKeyHelper.cs
+++ b/src/ElCamino.AspNetCore.Identity.AzureTable.Model/IKeyHelper.cs
@@ -1,5 +1,7 @@
 ﻿// MIT License Copyright 2020 (c) David Melendez. All rights reserved. See License.txt in the project root for license information.
 
+using System;
+
 namespace ElCamino.AspNetCore.Identity.AzureTable.Model
 {
     /// <summary>
@@ -128,7 +130,7 @@ namespace ElCamino.AspNetCore.Identity.AzureTable.Model
         /// <param name="plainLoginProvider"></param>
         /// <param name="plainProviderKey"></param>
         /// <returns></returns>
-        string GeneratePartitionKeyIndexByLogin(string plainLoginProvider, string plainProviderKey);
+        ReadOnlySpan<char> GeneratePartitionKeyIndexByLogin(string plainLoginProvider, string plainProviderKey);
 
         /// <summary>
         /// Generate key for RowKeyUserEmail

--- a/src/ElCamino.AspNetCore.Identity.AzureTable.Model/IKeyHelper.cs
+++ b/src/ElCamino.AspNetCore.Identity.AzureTable.Model/IKeyHelper.cs
@@ -157,7 +157,7 @@ namespace ElCamino.AspNetCore.Identity.AzureTable.Model
         /// </summary>
         /// <param name="plainUserName"></param>
         /// <returns></returns>
-        string GeneratePartitionKeyUserName(string? plainUserName);
+        ReadOnlySpan<char> GeneratePartitionKeyUserName(string? plainUserName);
 
         /// <summary>
         /// Generate key for RowKeyUserId

--- a/src/ElCamino.AspNetCore.Identity.AzureTable.Model/IdentityConfiguration.cs
+++ b/src/ElCamino.AspNetCore.Identity.AzureTable.Model/IdentityConfiguration.cs
@@ -14,11 +14,6 @@ namespace ElCamino.AspNetCore.Identity.AzureTable.Model
         public string? TablePrefix { get; set; }
 
         /// <summary>
-        /// Storage connection string
-        /// </summary>
-        public string? StorageConnectionString { get; set; }
-
-        /// <summary>
         /// Optional, default value is AspNetIndex
         /// </summary>
         public string? IndexTableName { get; set; }

--- a/src/ElCamino.AspNetCore.Identity.AzureTable.Model/IdentityRole.cs
+++ b/src/ElCamino.AspNetCore.Identity.AzureTable.Model/IdentityRole.cs
@@ -30,7 +30,7 @@ namespace ElCamino.AspNetCore.Identity.AzureTable.Model
         /// <returns></returns>
         public string PeekRowKey(IKeyHelper keyHelper)
         {
-            return keyHelper.GenerateRowKeyIdentityRole(Name);
+            return keyHelper.GenerateRowKeyIdentityRole(Name).ToString();
         }
 
         /// <inheritdoc/>

--- a/src/ElCamino.AspNetCore.Identity.AzureTable.Model/IdentityRole.cs
+++ b/src/ElCamino.AspNetCore.Identity.AzureTable.Model/IdentityRole.cs
@@ -20,7 +20,7 @@ namespace ElCamino.AspNetCore.Identity.AzureTable.Model
         public void GenerateKeys(IKeyHelper keyHelper)
         {
             RowKey = PeekRowKey(keyHelper);
-            PartitionKey = keyHelper.GeneratePartitionKeyIdentityRole(Name);
+            PartitionKey = keyHelper.GeneratePartitionKeyIdentityRole(Name).ToString();
             KeyVersion = keyHelper.KeyVersion;
         }
 

--- a/src/ElCamino.AspNetCore.Identity.AzureTable.Model/IdentityRoleClaim.cs
+++ b/src/ElCamino.AspNetCore.Identity.AzureTable.Model/IdentityRoleClaim.cs
@@ -31,7 +31,7 @@ namespace ElCamino.AspNetCore.Identity.AzureTable.Model
         /// <returns></returns>
         public string PeekRowKey(IKeyHelper keyHelper)
         {
-            return keyHelper.GenerateRowKeyIdentityRoleClaim(ClaimType, ClaimValue);
+            return keyHelper.GenerateRowKeyIdentityRoleClaim(ClaimType, ClaimValue).ToString();
         }
 
         /// <inheritdoc/>

--- a/src/ElCamino.AspNetCore.Identity.AzureTable.Model/IdentityUser.cs
+++ b/src/ElCamino.AspNetCore.Identity.AzureTable.Model/IdentityUser.cs
@@ -44,7 +44,7 @@ namespace ElCamino.AspNetCore.Identity.AzureTable.Model
         /// <returns></returns>
         public string PeekRowKey(IKeyHelper keyHelper)
         {
-            return keyHelper.GenerateRowKeyUserId(Id);
+            return keyHelper.GenerateRowKeyUserId(Id).ToString();
         }
 
         /// <inheritdoc/>

--- a/src/ElCamino.AspNetCore.Identity.AzureTable.Model/IdentityUser.cs
+++ b/src/ElCamino.AspNetCore.Identity.AzureTable.Model/IdentityUser.cs
@@ -30,7 +30,7 @@ namespace ElCamino.AspNetCore.Identity.AzureTable.Model
         {
             if (string.IsNullOrWhiteSpace(Id))
             {
-                Id = keyHelper.GenerateUserId();
+                Id = keyHelper.GenerateUserId().ToString();
             }
             RowKey = PeekRowKey(keyHelper);
             PartitionKey = RowKey;

--- a/src/ElCamino.AspNetCore.Identity.AzureTable.Model/IdentityUserClaim.cs
+++ b/src/ElCamino.AspNetCore.Identity.AzureTable.Model/IdentityUserClaim.cs
@@ -27,7 +27,7 @@ namespace ElCamino.AspNetCore.Identity.AzureTable.Model
         /// <returns></returns>
         public string PeekRowKey(IKeyHelper keyHelper)
         {
-            return keyHelper.GenerateRowKeyIdentityUserClaim(ClaimType, ClaimValue);
+            return keyHelper.GenerateRowKeyIdentityUserClaim(ClaimType, ClaimValue).ToString();
         }
 
         /// <inheritdoc/>

--- a/src/ElCamino.AspNetCore.Identity.AzureTable.Model/IdentityUserLogin.cs
+++ b/src/ElCamino.AspNetCore.Identity.AzureTable.Model/IdentityUserLogin.cs
@@ -32,7 +32,7 @@ namespace ElCamino.AspNetCore.Identity.AzureTable.Model
         /// <returns></returns>
         public string PeekRowKey(IKeyHelper keyHelper)
         {
-            return keyHelper.GenerateRowKeyIdentityUserLogin(LoginProvider, ProviderKey);
+            return keyHelper.GenerateRowKeyIdentityUserLogin(LoginProvider, ProviderKey).ToString();
         }
 
 

--- a/src/ElCamino.AspNetCore.Identity.AzureTable.Model/IdentityUserRole.cs
+++ b/src/ElCamino.AspNetCore.Identity.AzureTable.Model/IdentityUserRole.cs
@@ -30,7 +30,7 @@ namespace ElCamino.AspNetCore.Identity.AzureTable.Model
         /// <returns></returns>
         public string PeekRowKey(IKeyHelper keyHelper)
         {
-            return keyHelper.GenerateRowKeyIdentityUserRole(RoleName);
+            return keyHelper.GenerateRowKeyIdentityUserRole(RoleName).ToString();
         }
 
         /// <inheritdoc/>

--- a/src/ElCamino.AspNetCore.Identity.AzureTable.Model/IdentityUserToken.cs
+++ b/src/ElCamino.AspNetCore.Identity.AzureTable.Model/IdentityUserToken.cs
@@ -34,7 +34,7 @@ namespace ElCamino.AspNetCore.Identity.AzureTable.Model
         /// <returns></returns>
         public string PeekRowKey(IKeyHelper keyHelper)
         {
-            return keyHelper.GenerateRowKeyIdentityUserToken(LoginProvider, Name);
+            return keyHelper.GenerateRowKeyIdentityUserToken(LoginProvider, Name).ToString();
         }
 
     }

--- a/src/ElCamino.AspNetCore.Identity.AzureTable/ElCamino.AspNetCore.Identity.AzureTable.csproj
+++ b/src/ElCamino.AspNetCore.Identity.AzureTable/ElCamino.AspNetCore.Identity.AzureTable.csproj
@@ -5,8 +5,8 @@
     <Copyright>Copyright ©  David Melendez, MIT License</Copyright>
     <AssemblyTitle>Azure Table Storage Provider for ASP.NET Identity Core</AssemblyTitle>
     <Authors>David Melendez</Authors>
-    <TargetFrameworks>netstandard2.0;net6.0;net8.0</TargetFrameworks>
-    <LangVersion>12.0</LangVersion>
+    <TargetFrameworks>netstandard2.0;net8.0;net9.0</TargetFrameworks>
+    <LangVersion>13.0</LangVersion>
     <AssemblyName>ElCamino.AspNetCore.Identity.AzureTable</AssemblyName>
     <AssemblyOriginatorKeyFile>../../tools/key.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
@@ -21,7 +21,7 @@
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/dlmelendez/identityazuretable.git</RepositoryUrl>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
-    <Version>8.0</Version>
+    <Version>9.0</Version>
     <PackageProjectUrl>https://dlmelendez.github.io/identityazuretable</PackageProjectUrl>
     <!--<DebugType>Full</DebugType>-->
     <!-- DebugType Full is needed for test code coverage, but .nuget symbols doesn't like it-->
@@ -38,16 +38,16 @@
     <PackageReference Include="Azure.Data.Tables" Version="12.8.1" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net8.0' ">
-    <PackageReference Include="Microsoft.Extensions.Identity.Core" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Identity.Stores" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net9.0' ">
+    <PackageReference Include="Microsoft.Extensions.Identity.Core" Version="9.0.*" />
+    <PackageReference Include="Microsoft.Extensions.Identity.Stores" Version="9.0.*" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.*" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' != 'net8.0' ">
-    <PackageReference Include="Microsoft.Extensions.Identity.Core" Version="6.0.24" />
-    <PackageReference Include="Microsoft.Extensions.Identity.Stores" Version="6.0.24" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.1" />
+  <ItemGroup Condition=" '$(TargetFramework)' != 'net9.0' ">
+    <PackageReference Include="Microsoft.Extensions.Identity.Core" Version="8.0.*" />
+    <PackageReference Include="Microsoft.Extensions.Identity.Stores" Version="8.0.*" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.*" />
   </ItemGroup>
   
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">

--- a/src/ElCamino.AspNetCore.Identity.AzureTable/ElCamino.AspNetCore.Identity.AzureTable.csproj
+++ b/src/ElCamino.AspNetCore.Identity.AzureTable/ElCamino.AspNetCore.Identity.AzureTable.csproj
@@ -5,7 +5,7 @@
     <Copyright>Copyright ©  David Melendez, MIT License</Copyright>
     <AssemblyTitle>Azure Table Storage Provider for ASP.NET Identity Core</AssemblyTitle>
     <Authors>David Melendez</Authors>
-    <TargetFrameworks>netstandard2.0;net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
     <LangVersion>13.0</LangVersion>
     <AssemblyName>ElCamino.AspNetCore.Identity.AzureTable</AssemblyName>
     <AssemblyOriginatorKeyFile>../../tools/key.snk</AssemblyOriginatorKeyFile>

--- a/src/ElCamino.AspNetCore.Identity.AzureTable/Helpers/BaseKeyHelper.cs
+++ b/src/ElCamino.AspNetCore.Identity.AzureTable/Helpers/BaseKeyHelper.cs
@@ -172,7 +172,7 @@ namespace ElCamino.AspNetCore.Identity.AzureTable.Helpers
         }
 
         /// <inheritdoc/>
-        public virtual string ParsePartitionKeyIdentityRoleFromRowKey(string rowKey)
+        public virtual ReadOnlySpan<char> ParsePartitionKeyIdentityRoleFromRowKey(string rowKey)
         {
             return rowKey.AsSpan().Slice(PreFixIdentityRole.Length, 1).ToString();
         }

--- a/src/ElCamino.AspNetCore.Identity.AzureTable/Helpers/BaseKeyHelper.cs
+++ b/src/ElCamino.AspNetCore.Identity.AzureTable/Helpers/BaseKeyHelper.cs
@@ -116,7 +116,7 @@ namespace ElCamino.AspNetCore.Identity.AzureTable.Helpers
         }
 
         /// <inheritdoc/>
-        public virtual string GeneratePartitionKeyUserName(string? plainUserName)
+        public virtual ReadOnlySpan<char> GeneratePartitionKeyUserName(string? plainUserName)
         {
             var hash = ConvertKeyToHash(plainUserName?.ToUpper());
             return string.Format(FormatterIdentityUserName, hash.ToString());

--- a/src/ElCamino.AspNetCore.Identity.AzureTable/Helpers/BaseKeyHelper.cs
+++ b/src/ElCamino.AspNetCore.Identity.AzureTable/Helpers/BaseKeyHelper.cs
@@ -103,7 +103,7 @@ namespace ElCamino.AspNetCore.Identity.AzureTable.Helpers
         }
 
         /// <inheritdoc/>
-        public virtual string GenerateRowKeyUserId(string? plainUserId)
+        public virtual ReadOnlySpan<char> GenerateRowKeyUserId(string? plainUserId)
         {
             var hash = ConvertKeyToHash(plainUserId?.ToUpper());
             return string.Format(FormatterIdentityUserId, hash.ToString());

--- a/src/ElCamino.AspNetCore.Identity.AzureTable/Helpers/BaseKeyHelper.cs
+++ b/src/ElCamino.AspNetCore.Identity.AzureTable/Helpers/BaseKeyHelper.cs
@@ -110,7 +110,7 @@ namespace ElCamino.AspNetCore.Identity.AzureTable.Helpers
         }
 
         /// <inheritdoc/>
-        public virtual string GenerateRowKeyUserName(string? plainUserName)
+        public virtual ReadOnlySpan<char> GenerateRowKeyUserName(string? plainUserName)
         {
             return GeneratePartitionKeyUserName(plainUserName);
         }

--- a/src/ElCamino.AspNetCore.Identity.AzureTable/Helpers/BaseKeyHelper.cs
+++ b/src/ElCamino.AspNetCore.Identity.AzureTable/Helpers/BaseKeyHelper.cs
@@ -137,7 +137,7 @@ namespace ElCamino.AspNetCore.Identity.AzureTable.Helpers
         }
 
         /// <inheritdoc/>
-        public virtual string GeneratePartitionKeyIdentityRole(string? plainRoleName)
+        public virtual ReadOnlySpan<char> GeneratePartitionKeyIdentityRole(string? plainRoleName)
         {
             var hash = ConvertKeyToHash(plainRoleName?.ToUpper());
             if(hash.IsEmpty)

--- a/src/ElCamino.AspNetCore.Identity.AzureTable/Helpers/BaseKeyHelper.cs
+++ b/src/ElCamino.AspNetCore.Identity.AzureTable/Helpers/BaseKeyHelper.cs
@@ -186,7 +186,7 @@ namespace ElCamino.AspNetCore.Identity.AzureTable.Helpers
         }
 
         /// <inheritdoc/>
-        public double KeyVersion => 8.0;
+        public double KeyVersion => 9.0;
 
         /// <summary>
         /// Convert Key Data to a hex hash string

--- a/src/ElCamino.AspNetCore.Identity.AzureTable/Helpers/BaseKeyHelper.cs
+++ b/src/ElCamino.AspNetCore.Identity.AzureTable/Helpers/BaseKeyHelper.cs
@@ -97,7 +97,7 @@ namespace ElCamino.AspNetCore.Identity.AzureTable.Helpers
         }
 
         /// <inheritdoc/>
-        public virtual string GenerateUserId()
+        public virtual ReadOnlySpan<char> GenerateUserId()
         {
             return Guid.NewGuid().ToString("N");
         }

--- a/src/ElCamino.AspNetCore.Identity.AzureTable/Helpers/BaseKeyHelper.cs
+++ b/src/ElCamino.AspNetCore.Identity.AzureTable/Helpers/BaseKeyHelper.cs
@@ -164,7 +164,7 @@ namespace ElCamino.AspNetCore.Identity.AzureTable.Helpers
         }
 
         /// <inheritdoc/>
-        public virtual string GenerateRowKeyIdentityUserToken(string? loginProvider, string? name)
+        public virtual ReadOnlySpan<char> GenerateRowKeyIdentityUserToken(string? loginProvider, string? name)
         {
             var strTemp = string.Format("{0}_{1}", loginProvider?.ToUpper(), name?.ToUpper()).AsSpan();
             var hash = ConvertKeyToHash(strTemp);

--- a/src/ElCamino.AspNetCore.Identity.AzureTable/Helpers/BaseKeyHelper.cs
+++ b/src/ElCamino.AspNetCore.Identity.AzureTable/Helpers/BaseKeyHelper.cs
@@ -130,7 +130,7 @@ namespace ElCamino.AspNetCore.Identity.AzureTable.Helpers
         }
 
         /// <inheritdoc/>
-        public virtual string GenerateRowKeyIdentityRole(string? plainRoleName)
+        public virtual ReadOnlySpan<char> GenerateRowKeyIdentityRole(string? plainRoleName)
         {
             var hash = ConvertKeyToHash(plainRoleName?.ToUpper());
             return string.Format(FormatterIdentityRole, hash.ToString());
@@ -156,7 +156,7 @@ namespace ElCamino.AspNetCore.Identity.AzureTable.Helpers
         }
 
         /// <inheritdoc/>
-        public virtual string GenerateRowKeyIdentityRoleClaim(string? claimType, string? claimValue)
+        public virtual ReadOnlySpan<char> GenerateRowKeyIdentityRoleClaim(string? claimType, string? claimValue)
         {
             var strTemp = string.Format("{0}_{1}", claimType?.ToUpper(), claimValue?.ToUpper()).AsSpan();
             var hash = ConvertKeyToHash(strTemp);

--- a/src/ElCamino.AspNetCore.Identity.AzureTable/Helpers/BaseKeyHelper.cs
+++ b/src/ElCamino.AspNetCore.Identity.AzureTable/Helpers/BaseKeyHelper.cs
@@ -90,7 +90,7 @@ namespace ElCamino.AspNetCore.Identity.AzureTable.Helpers
         }
 
         /// <inheritdoc/>
-        public virtual string GenerateRowKeyUserEmail(string? plainEmail)
+        public virtual ReadOnlySpan<char> GenerateRowKeyUserEmail(string? plainEmail)
         {
             var hash = ConvertKeyToHash(plainEmail?.ToUpper());
             return string.Format(FormatterIdentityUserEmail, hash.ToString());

--- a/src/ElCamino.AspNetCore.Identity.AzureTable/Helpers/BaseKeyHelper.cs
+++ b/src/ElCamino.AspNetCore.Identity.AzureTable/Helpers/BaseKeyHelper.cs
@@ -84,16 +84,16 @@ namespace ElCamino.AspNetCore.Identity.AzureTable.Helpers
         /// <inheritdoc/>
         public virtual string GeneratePartitionKeyIndexByLogin(string plainLoginProvider, string plainProviderKey)
         {
-            string strTemp = string.Format("{0}_{1}", plainLoginProvider?.ToUpper(), plainProviderKey?.ToUpper());
-            string? hash = ConvertKeyToHash(strTemp);
-            return string.Format(FormatterIdentityUserLogin, hash);
+            var strTemp = string.Format("{0}_{1}", plainLoginProvider?.ToUpper(), plainProviderKey?.ToUpper()).AsSpan();
+            var hash = ConvertKeyToHash(strTemp);
+            return string.Format(FormatterIdentityUserLogin, hash.ToString());
         }
 
         /// <inheritdoc/>
         public virtual string GenerateRowKeyUserEmail(string? plainEmail)
         {
-            string? hash = ConvertKeyToHash(plainEmail?.ToUpper());
-            return string.Format(FormatterIdentityUserEmail, hash);
+            var hash = ConvertKeyToHash(plainEmail?.ToUpper());
+            return string.Format(FormatterIdentityUserEmail, hash.ToString());
         }
 
         /// <inheritdoc/>
@@ -105,8 +105,8 @@ namespace ElCamino.AspNetCore.Identity.AzureTable.Helpers
         /// <inheritdoc/>
         public virtual string GenerateRowKeyUserId(string? plainUserId)
         {
-            string? hash = ConvertKeyToHash(plainUserId?.ToUpper());
-            return string.Format(FormatterIdentityUserId, hash);
+            var hash = ConvertKeyToHash(plainUserId?.ToUpper());
+            return string.Format(FormatterIdentityUserId, hash.ToString());
         }
 
         /// <inheritdoc/>
@@ -118,67 +118,71 @@ namespace ElCamino.AspNetCore.Identity.AzureTable.Helpers
         /// <inheritdoc/>
         public virtual string GeneratePartitionKeyUserName(string? plainUserName)
         {
-            string? hash = ConvertKeyToHash(plainUserName?.ToUpper());
-            return string.Format(FormatterIdentityUserName, hash);
+            var hash = ConvertKeyToHash(plainUserName?.ToUpper());
+            return string.Format(FormatterIdentityUserName, hash.ToString());
         }
 
         /// <inheritdoc/>
         public virtual string GenerateRowKeyIdentityUserRole(string? plainRoleName)
         {
-            string? hash = ConvertKeyToHash(plainRoleName?.ToUpper());
-            return string.Format(FormatterIdentityUserRole, hash);
+            var hash = ConvertKeyToHash(plainRoleName?.ToUpper());
+            return string.Format(FormatterIdentityUserRole, hash.ToString());
         }
 
         /// <inheritdoc/>
         public virtual string GenerateRowKeyIdentityRole(string? plainRoleName)
         {
-            string? hash = ConvertKeyToHash(plainRoleName?.ToUpper());
-            return string.Format(FormatterIdentityRole, hash);
+            var hash = ConvertKeyToHash(plainRoleName?.ToUpper());
+            return string.Format(FormatterIdentityRole, hash.ToString());
         }
 
         /// <inheritdoc/>
         public virtual string GeneratePartitionKeyIdentityRole(string? plainRoleName)
         {
-            string? hash = ConvertKeyToHash(plainRoleName?.ToUpper());
-            return hash?.Substring(startIndex: 0, length: 1)??string.Empty;
+            var hash = ConvertKeyToHash(plainRoleName?.ToUpper());
+            if(hash.IsEmpty)
+            {
+                return string.Empty;
+            }
+            return hash.Slice(start: 0, length: 1).ToString();
         }
 
         /// <inheritdoc/>
         public virtual string GenerateRowKeyIdentityUserClaim(string? claimType, string? claimValue)
         {
-            string strTemp = string.Format("{0}_{1}", claimType?.ToUpper(), claimValue?.ToUpper());
-            string? hash = ConvertKeyToHash(strTemp);
-            return string.Format(FormatterIdentityUserClaim, hash);
+            var strTemp = string.Format("{0}_{1}", claimType?.ToUpper(), claimValue?.ToUpper()).AsSpan();
+            var hash = ConvertKeyToHash(strTemp);
+            return string.Format(FormatterIdentityUserClaim, hash.ToString());
         }
 
         /// <inheritdoc/>
         public virtual string GenerateRowKeyIdentityRoleClaim(string? claimType, string? claimValue)
         {
-            string strTemp = string.Format("{0}_{1}", claimType?.ToUpper(), claimValue?.ToUpper());
-            string? hash = ConvertKeyToHash(strTemp);
-            return string.Format(FormatterIdentityRoleClaim, hash);
+            var strTemp = string.Format("{0}_{1}", claimType?.ToUpper(), claimValue?.ToUpper()).AsSpan();
+            var hash = ConvertKeyToHash(strTemp);
+            return string.Format(FormatterIdentityRoleClaim, hash.ToString());
         }
 
         /// <inheritdoc/>
         public virtual string GenerateRowKeyIdentityUserToken(string? loginProvider, string? name)
         {
-            string strTemp = string.Format("{0}_{1}", loginProvider?.ToUpper(), name?.ToUpper());
-            string? hash = ConvertKeyToHash(strTemp);
-            return string.Format(FormatterIdentityUserToken, hash);
+            var strTemp = string.Format("{0}_{1}", loginProvider?.ToUpper(), name?.ToUpper()).AsSpan();
+            var hash = ConvertKeyToHash(strTemp);
+            return string.Format(FormatterIdentityUserToken, hash.ToString());
         }
 
         /// <inheritdoc/>
         public virtual string ParsePartitionKeyIdentityRoleFromRowKey(string rowKey)
         {
-            return rowKey.Substring(PreFixIdentityRole.Length, 1);
+            return rowKey.AsSpan().Slice(PreFixIdentityRole.Length, 1).ToString();
         }
 
         /// <inheritdoc/>
         public virtual string GenerateRowKeyIdentityUserLogin(string? loginProvider, string? providerKey)
         {
-            string strTemp = string.Format("{0}_{1}", loginProvider?.ToUpper(), providerKey?.ToUpper());
-            string? hash = ConvertKeyToHash(strTemp);
-            return string.Format(FormatterIdentityUserLogin, hash);
+            var strTemp = string.Format("{0}_{1}", loginProvider?.ToUpper(), providerKey?.ToUpper()).AsSpan();
+            var hash = ConvertKeyToHash(strTemp);
+            return string.Format(FormatterIdentityUserLogin, hash.ToString());
         }
 
         /// <inheritdoc/>
@@ -189,7 +193,7 @@ namespace ElCamino.AspNetCore.Identity.AzureTable.Helpers
         /// </summary>
         /// <param name="input">Plain text input</param>
         /// <returns>Returns a hex string</returns>
-        public abstract string? ConvertKeyToHash(string? input);
+        public abstract ReadOnlySpan<char> ConvertKeyToHash(ReadOnlySpan<char> input);
 
         /// <summary>
         /// Left only for backwards compat for older frameworks.
@@ -221,18 +225,16 @@ namespace ElCamino.AspNetCore.Identity.AzureTable.Helpers
             return sBuilder.ToString();
         }
 
-#if NET6_0_OR_GREATER
         /// <summary>
         /// Format byte array to hex string
         /// </summary>
         /// <param name="hashedData">byte array to format</param>
         /// <returns></returns>
-        protected static string FormatHashedData(byte[] hashedData)
+        protected static string FormatHashedData(ReadOnlySpan<byte> hashedData)
         {
             // Convert the input string to a byte array and compute the hash. 
             return Convert.ToHexString(hashedData).ToLowerInvariant();
         }
-#endif
 
     }
 }

--- a/src/ElCamino.AspNetCore.Identity.AzureTable/Helpers/BaseKeyHelper.cs
+++ b/src/ElCamino.AspNetCore.Identity.AzureTable/Helpers/BaseKeyHelper.cs
@@ -82,7 +82,7 @@ namespace ElCamino.AspNetCore.Identity.AzureTable.Helpers
         public virtual string FormatterIdentityRoleClaim => TableConstants.RowKeyConstants.FormatterIdentityRoleClaim;
 
         /// <inheritdoc/>
-        public virtual string GeneratePartitionKeyIndexByLogin(string plainLoginProvider, string plainProviderKey)
+        public virtual ReadOnlySpan<char> GeneratePartitionKeyIndexByLogin(string plainLoginProvider, string plainProviderKey)
         {
             var strTemp = string.Format("{0}_{1}", plainLoginProvider?.ToUpper(), plainProviderKey?.ToUpper()).AsSpan();
             var hash = ConvertKeyToHash(strTemp);

--- a/src/ElCamino.AspNetCore.Identity.AzureTable/Helpers/BaseKeyHelper.cs
+++ b/src/ElCamino.AspNetCore.Identity.AzureTable/Helpers/BaseKeyHelper.cs
@@ -178,7 +178,7 @@ namespace ElCamino.AspNetCore.Identity.AzureTable.Helpers
         }
 
         /// <inheritdoc/>
-        public virtual string GenerateRowKeyIdentityUserLogin(string? loginProvider, string? providerKey)
+        public virtual ReadOnlySpan<char> GenerateRowKeyIdentityUserLogin(string? loginProvider, string? providerKey)
         {
             var strTemp = string.Format("{0}_{1}", loginProvider?.ToUpper(), providerKey?.ToUpper()).AsSpan();
             var hash = ConvertKeyToHash(strTemp);

--- a/src/ElCamino.AspNetCore.Identity.AzureTable/Helpers/BaseKeyHelper.cs
+++ b/src/ElCamino.AspNetCore.Identity.AzureTable/Helpers/BaseKeyHelper.cs
@@ -148,7 +148,7 @@ namespace ElCamino.AspNetCore.Identity.AzureTable.Helpers
         }
 
         /// <inheritdoc/>
-        public virtual string GenerateRowKeyIdentityUserClaim(string? claimType, string? claimValue)
+        public virtual ReadOnlySpan<char> GenerateRowKeyIdentityUserClaim(string? claimType, string? claimValue)
         {
             var strTemp = string.Format("{0}_{1}", claimType?.ToUpper(), claimValue?.ToUpper()).AsSpan();
             var hash = ConvertKeyToHash(strTemp);

--- a/src/ElCamino.AspNetCore.Identity.AzureTable/Helpers/BaseKeyHelper.cs
+++ b/src/ElCamino.AspNetCore.Identity.AzureTable/Helpers/BaseKeyHelper.cs
@@ -123,7 +123,7 @@ namespace ElCamino.AspNetCore.Identity.AzureTable.Helpers
         }
 
         /// <inheritdoc/>
-        public virtual string GenerateRowKeyIdentityUserRole(string? plainRoleName)
+        public virtual ReadOnlySpan<char> GenerateRowKeyIdentityUserRole(string? plainRoleName)
         {
             var hash = ConvertKeyToHash(plainRoleName?.ToUpper());
             return string.Format(FormatterIdentityUserRole, hash.ToString());

--- a/src/ElCamino.AspNetCore.Identity.AzureTable/Helpers/SHA256KeyHelper.cs
+++ b/src/ElCamino.AspNetCore.Identity.AzureTable/Helpers/SHA256KeyHelper.cs
@@ -23,11 +23,10 @@ namespace ElCamino.AspNetCore.Identity.AzureTable.Helpers
         }
 
         /// <inheritdoc/>
-        public override string GenerateRowKeyUserId(string? plainUserId)
+        public override ReadOnlySpan<char> GenerateRowKeyUserId(string? plainUserId)
         {
             ArgumentNullException.ThrowIfNull(plainUserId);
             return string.Format(FormatterIdentityUserId, plainUserId);
         }
-
     }
 }

--- a/src/ElCamino.AspNetCore.Identity.AzureTable/Helpers/SHA256KeyHelper.cs
+++ b/src/ElCamino.AspNetCore.Identity.AzureTable/Helpers/SHA256KeyHelper.cs
@@ -25,6 +25,7 @@ namespace ElCamino.AspNetCore.Identity.AzureTable.Helpers
         /// <inheritdoc/>
         public override string GenerateRowKeyUserId(string? plainUserId)
         {
+            ArgumentNullException.ThrowIfNull(plainUserId);
             return string.Format(FormatterIdentityUserId, plainUserId);
         }
 

--- a/src/ElCamino.AspNetCore.Identity.AzureTable/IdentityAzureTableBuilderExtensions.cs
+++ b/src/ElCamino.AspNetCore.Identity.AzureTable/IdentityAzureTableBuilderExtensions.cs
@@ -56,13 +56,9 @@ namespace Microsoft.Extensions.DependencyInjection
             IKeyHelper? keyHelper = null)
             where TContext : IdentityCloudContext
         {
-#if NET6_0_OR_GREATER
             ArgumentNullException.ThrowIfNull(configAction, nameof(configAction));
             ArgumentNullException.ThrowIfNull(tableServiceClientAction, nameof(tableServiceClientAction));
-#else
-            _ = configAction ?? throw new ArgumentNullException(nameof(configAction));
-            _ = tableServiceClientAction ?? throw new ArgumentNullException(nameof(tableServiceClientAction));
-#endif
+
             builder.Services.AddSingleton<IKeyHelper>(keyHelper ?? new DefaultKeyHelper());
 
             builder.Services.AddSingleton<IdentityConfiguration>(configAction);

--- a/src/ElCamino.AspNetCore.Identity.AzureTable/IdentityAzureTableBuilderExtensions.cs
+++ b/src/ElCamino.AspNetCore.Identity.AzureTable/IdentityAzureTableBuilderExtensions.cs
@@ -1,12 +1,15 @@
 ﻿// MIT License Copyright 2020 (c) David Melendez. All rights reserved. See License.txt in the project root for license information.
 
 using System;
+using Azure.Data.Tables;
 using ElCamino.AspNetCore.Identity.AzureTable;
 using ElCamino.AspNetCore.Identity.AzureTable.Helpers;
 using ElCamino.AspNetCore.Identity.AzureTable.Model;
 using Microsoft.AspNetCore.Identity;
 
+#pragma warning disable IDE0130 // Namespace does not match folder structure
 namespace Microsoft.Extensions.DependencyInjection
+#pragma warning restore IDE0130 // Namespace does not match folder structure
 {
     /// <summary>
     /// IdentityBuilder extensions for di
@@ -14,19 +17,31 @@ namespace Microsoft.Extensions.DependencyInjection
     public static class IdentityAzureTableBuilderExtensions
     {
         /// <summary>
+        /// Use this key to retrieve the <see cref="TableServiceClient"/> for the Identity Azure Tables
+        /// </summary>
+        public const string IdentityAzureTableServiceClientKey = "IdentityAzureTableServiceClientKey";
+
+        /// <summary>
         /// Use this to load and configure the Identity Azure Tables into the aspnet identity pipeline.
         /// Note: <see cref="IdentityBuilder.AddRoles{TRole}"/> prior to calling this method in the pipeline if you need Roles functionality, otherwise the RoleStore will not be loaded.
         /// </summary>
         /// <typeparam name="TContext">Use or extend <see cref="IdentityCloudContext"/></typeparam>
         /// <param name="builder"><see cref="IdentityBuilder"/> aspnet identity pipeline</param>
         /// <param name="configAction"><see cref="IdentityConfiguration"/></param>
+        /// <param name="tableServiceClientAction"><see cref="TableServiceClient"/></param>
         /// <param name="keyHelper">Use <see cref="DefaultKeyHelper"/> that uses SHA1, <see cref="SHA256KeyHelper"/> or a custom keyhelper that implements <see cref="IKeyHelper"/> </param>
         /// <returns><see cref="IdentityBuilder"/></returns>
-        public static IdentityBuilder AddAzureTableStores<TContext>(this IdentityBuilder builder, Func<IdentityConfiguration> configAction,
+        public static IdentityBuilder AddAzureTableStores<TContext>(this IdentityBuilder builder, 
+            Func<IdentityConfiguration> configAction,
+            Func<TableServiceClient>? tableServiceClientAction = null,
             IKeyHelper? keyHelper = null)
             where TContext : IdentityCloudContext
         {
-            return builder.AddAzureTableStores<TContext>(_ => configAction(), keyHelper);
+            if (tableServiceClientAction is not null)
+            {
+                return builder.AddAzureTableStores<TContext>(_ => configAction(), _ => tableServiceClientAction(), keyHelper);
+            }
+            return builder.AddAzureTableStores<TContext>(_ => configAction(), null, keyHelper);
         }
 
         /// <summary>
@@ -36,9 +51,12 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <typeparam name="TContext">Use or extend <see cref="IdentityCloudContext"/></typeparam>
         /// <param name="builder"><see cref="IdentityBuilder"/> aspnet identity pipeline</param>
         /// <param name="configAction"><see cref="IdentityConfiguration"/></param>
+        /// <param name="tableServiceClientAction"><see cref="TableServiceClient"/></param>
         /// <param name="keyHelper">Use <see cref="DefaultKeyHelper"/> that uses SHA1, <see cref="SHA256KeyHelper"/> or a custom keyhelper that implements <see cref="IKeyHelper"/> </param>
         /// <returns><see cref="IdentityBuilder"/></returns>
-        public static IdentityBuilder AddAzureTableStores<TContext>(this IdentityBuilder builder, Func<IServiceProvider, IdentityConfiguration> configAction,
+        public static IdentityBuilder AddAzureTableStores<TContext>(this IdentityBuilder builder,
+            Func<IServiceProvider, IdentityConfiguration> configAction,
+            Func<IServiceProvider, TableServiceClient>? tableServiceClientAction = null,
             IKeyHelper? keyHelper = null)
             where TContext : IdentityCloudContext
         {
@@ -46,9 +64,22 @@ namespace Microsoft.Extensions.DependencyInjection
             builder.Services.AddSingleton<IKeyHelper>(keyHelper ?? new DefaultKeyHelper());
 
             builder.Services.AddSingleton<IdentityConfiguration>(configAction);
-
+                
             Type contextType = typeof(TContext);
-            builder.Services.AddSingleton(contextType, contextType);
+
+            if (tableServiceClientAction is not null)
+            {
+                builder.Services.AddKeyedSingleton<TableServiceClient>(IdentityAzureTableServiceClientKey, (sp, o) => tableServiceClientAction(sp));
+                builder.Services.AddSingleton(contextType, sp => 
+                { 
+                    return Activator.CreateInstance(contextType, [sp.GetRequiredService<IdentityConfiguration>(), sp.GetRequiredKeyedService<TableServiceClient>(IdentityAzureTableServiceClientKey)]) as TContext
+                        ?? throw new InvalidOperationException($"Unable to create instance of {contextType.FullName}. Must have a constructor that accepts {nameof(IdentityConfiguration)}, {nameof(TableServiceClient)}");
+                });
+            }
+            else
+            {
+                builder.Services.AddSingleton(contextType, contextType);
+            }
 
             Type userStoreType = builder.RoleType is not null ? typeof(UserStore<,,>).MakeGenericType(builder.UserType, builder.RoleType, contextType)
                 : typeof(UserOnlyStore<,>).MakeGenericType(builder.UserType, contextType);

--- a/src/ElCamino.AspNetCore.Identity.AzureTable/IdentityCloudContext.cs
+++ b/src/ElCamino.AspNetCore.Identity.AzureTable/IdentityCloudContext.cs
@@ -36,6 +36,28 @@ namespace ElCamino.AspNetCore.Identity.AzureTable
             _userTable = _client.GetTableClient(FormatTableNameWithPrefix(config!.TablePrefix, !string.IsNullOrWhiteSpace(config!.UserTableName) ? config!.UserTableName! : TableConstants.TableNames.UsersTable));
         }
 
+        /// <summary>
+        /// Uses <see cref="IdentityConfiguration"/> and <see cref="TableServiceClient"/> to configure identity table storage access
+        /// </summary>
+        /// <param name="config">Accepts <see cref="IdentityConfiguration"/></param>
+        /// <param name="client">Accepts <see cref="TableServiceClient"/></param>
+        public IdentityCloudContext(IdentityConfiguration config, TableServiceClient client)
+        {
+#if NET6_0_OR_GREATER
+            ArgumentNullException.ThrowIfNull(config, nameof(config));
+            ArgumentNullException.ThrowIfNull(client, nameof(client));
+#else
+            _ = config ?? throw new ArgumentNullException(nameof(config));
+            _ = client ?? throw new ArgumentNullException(nameof(client));
+#endif
+
+            _client = client;
+            _indexTable = _client.GetTableClient(FormatTableNameWithPrefix(config!.TablePrefix, !string.IsNullOrWhiteSpace(config!.IndexTableName) ? config!.IndexTableName! : TableConstants.TableNames.IndexTable));
+            _roleTable = _client.GetTableClient(FormatTableNameWithPrefix(config!.TablePrefix, !string.IsNullOrWhiteSpace(config!.RoleTableName) ? config!.RoleTableName! : TableConstants.TableNames.RolesTable));
+            _userTable = _client.GetTableClient(FormatTableNameWithPrefix(config!.TablePrefix, !string.IsNullOrWhiteSpace(config!.UserTableName) ? config!.UserTableName! : TableConstants.TableNames.UsersTable));
+        }
+
+
         private static string FormatTableNameWithPrefix(string? tablePrefix, string baseTableName)
         {
             if (!string.IsNullOrWhiteSpace(tablePrefix))

--- a/src/ElCamino.AspNetCore.Identity.AzureTable/IdentityCloudContext.cs
+++ b/src/ElCamino.AspNetCore.Identity.AzureTable/IdentityCloudContext.cs
@@ -16,27 +16,6 @@ namespace ElCamino.AspNetCore.Identity.AzureTable
         private readonly TableClient _userTable;
 
         /// <summary>
-        /// Uses <see cref="IdentityConfiguration"/> to configure identity table storage access
-        /// </summary>
-        /// <param name="config">Accepts <see cref="IdentityConfiguration"/></param>
-        public IdentityCloudContext(IdentityConfiguration config)
-        {
-#if NET6_0_OR_GREATER
-            ArgumentNullException.ThrowIfNull(config, nameof(config));
-#else
-            if (config is null)
-            {
-                throw new ArgumentNullException(nameof(config));
-            }
-#endif
-
-            _client = new TableServiceClient(config.StorageConnectionString);
-            _indexTable = _client.GetTableClient(FormatTableNameWithPrefix(config!.TablePrefix, !string.IsNullOrWhiteSpace(config!.IndexTableName) ? config!.IndexTableName! : TableConstants.TableNames.IndexTable));
-            _roleTable = _client.GetTableClient(FormatTableNameWithPrefix(config!.TablePrefix, !string.IsNullOrWhiteSpace(config!.RoleTableName) ? config!.RoleTableName! : TableConstants.TableNames.RolesTable));
-            _userTable = _client.GetTableClient(FormatTableNameWithPrefix(config!.TablePrefix, !string.IsNullOrWhiteSpace(config!.UserTableName) ? config!.UserTableName! : TableConstants.TableNames.UsersTable));
-        }
-
-        /// <summary>
         /// Uses <see cref="IdentityConfiguration"/> and <see cref="TableServiceClient"/> to configure identity table storage access
         /// </summary>
         /// <param name="config">Accepts <see cref="IdentityConfiguration"/></param>

--- a/src/ElCamino.AspNetCore.Identity.AzureTable/IdentityCloudContext.cs
+++ b/src/ElCamino.AspNetCore.Identity.AzureTable/IdentityCloudContext.cs
@@ -22,13 +22,8 @@ namespace ElCamino.AspNetCore.Identity.AzureTable
         /// <param name="client">Accepts <see cref="TableServiceClient"/></param>
         public IdentityCloudContext(IdentityConfiguration config, TableServiceClient client)
         {
-#if NET6_0_OR_GREATER
             ArgumentNullException.ThrowIfNull(config, nameof(config));
             ArgumentNullException.ThrowIfNull(client, nameof(client));
-#else
-            _ = config ?? throw new ArgumentNullException(nameof(config));
-            _ = client ?? throw new ArgumentNullException(nameof(client));
-#endif
 
             _client = client;
             _indexTable = _client.GetTableClient(FormatTableNameWithPrefix(config!.TablePrefix, !string.IsNullOrWhiteSpace(config!.IndexTableName) ? config!.IndexTableName! : TableConstants.TableNames.IndexTable));

--- a/src/ElCamino.AspNetCore.Identity.AzureTable/RoleStore.cs
+++ b/src/ElCamino.AspNetCore.Identity.AzureTable/RoleStore.cs
@@ -84,11 +84,8 @@ namespace ElCamino.AspNetCore.Identity.AzureTable
         {
             cancellationToken.ThrowIfCancellationRequested();
             ThrowIfDisposed();
-#if NET6_0_OR_GREATER
             ArgumentNullException.ThrowIfNull(role);
-#else
-            if (role is null) throw new ArgumentNullException(nameof(role));
-#endif
+
             ((Model.IGenerateKeys)role).GenerateKeys(_keyHelper);
 
             // Execute the insert operation.
@@ -101,11 +98,8 @@ namespace ElCamino.AspNetCore.Identity.AzureTable
         {
             cancellationToken.ThrowIfCancellationRequested();
             ThrowIfDisposed();
-#if NET6_0_OR_GREATER
             ArgumentNullException.ThrowIfNull(role);
-#else
-            if (role is null) throw new ArgumentNullException(nameof(role));
-#endif
+
             // Execute the insert operation.
             _ = await _roleTable.DeleteEntityAsync(role.PartitionKey, role.RowKey, TableConstants.ETagWildcard, cancellationToken: cancellationToken).ConfigureAwait(false);
             return IdentityResult.Success;
@@ -187,14 +181,8 @@ namespace ElCamino.AspNetCore.Identity.AzureTable
         {
             cancellationToken.ThrowIfCancellationRequested();
             ThrowIfDisposed();
-#if NET6_0_OR_GREATER
             ArgumentNullException.ThrowIfNull(role);
-#else
-            if (role is null)
-            {
-                throw new ArgumentNullException(nameof(role));
-            }
-#endif
+
             var partitionFilter = TableQuery.GenerateFilterCondition(nameof(TableEntity.PartitionKey), QueryComparisons.Equal, role.Id.ToString() ?? string.Empty);
 
             var rowFilter1 = TableQuery.GenerateFilterCondition(nameof(TableEntity.RowKey), QueryComparisons.GreaterThanOrEqual, _keyHelper.PreFixIdentityUserToken);
@@ -215,20 +203,10 @@ namespace ElCamino.AspNetCore.Identity.AzureTable
         {
             cancellationToken.ThrowIfCancellationRequested();
             ThrowIfDisposed();
-#if NET6_0_OR_GREATER
+
             ArgumentNullException.ThrowIfNull(role);
             ArgumentNullException.ThrowIfNull(claim);
-#else
 
-            if (role is null)
-            {
-                throw new ArgumentNullException(nameof(role));
-            }
-            if (claim is null)
-            {
-                throw new ArgumentNullException(nameof(claim));
-            }
-#endif
             TRoleClaim item = Activator.CreateInstance<TRoleClaim>();
             item.RoleId = role.Id;
             item.ClaimType = claim.Type;
@@ -243,19 +221,9 @@ namespace ElCamino.AspNetCore.Identity.AzureTable
         {
             cancellationToken.ThrowIfCancellationRequested();
             ThrowIfDisposed();
-#if NET6_0_OR_GREATER
             ArgumentNullException.ThrowIfNull(role);
             ArgumentNullException.ThrowIfNull(claim);
-#else
-            if (role is null)
-            {
-                throw new ArgumentNullException(nameof(role));
-            }
-            if (claim is null)
-            {
-                throw new ArgumentNullException(nameof(claim));
-            }
-#endif
+
             if (string.IsNullOrWhiteSpace(claim.Type))
             {
                 throw new ArgumentException(IdentityResources.ValueCannotBeNullOrEmpty, nameof(claim));

--- a/src/ElCamino.AspNetCore.Identity.AzureTable/RoleStore.cs
+++ b/src/ElCamino.AspNetCore.Identity.AzureTable/RoleStore.cs
@@ -133,7 +133,7 @@ namespace ElCamino.AspNetCore.Identity.AzureTable
             cancellationToken.ThrowIfCancellationRequested();
             ThrowIfDisposed();
 
-            return await _roleTable!.GetEntityOrDefaultAsync<TRole>(_keyHelper.ParsePartitionKeyIdentityRoleFromRowKey(roleId),
+            return await _roleTable!.GetEntityOrDefaultAsync<TRole>(_keyHelper.ParsePartitionKeyIdentityRoleFromRowKey(roleId).ToString(),
                 roleId.ToString(), cancellationToken: cancellationToken).ConfigureAwait(false);
         }
 

--- a/src/ElCamino.AspNetCore.Identity.AzureTable/RoleStore.cs
+++ b/src/ElCamino.AspNetCore.Identity.AzureTable/RoleStore.cs
@@ -143,7 +143,7 @@ namespace ElCamino.AspNetCore.Identity.AzureTable
             cancellationToken.ThrowIfCancellationRequested();
             ThrowIfDisposed();
 
-            return await _roleTable.GetEntityOrDefaultAsync<TRole>(_keyHelper.GeneratePartitionKeyIdentityRole(roleName),
+            return await _roleTable.GetEntityOrDefaultAsync<TRole>(_keyHelper.GeneratePartitionKeyIdentityRole(roleName).ToString(),
             _keyHelper.GenerateRowKeyIdentityRole(roleName).ToString(), cancellationToken: cancellationToken).ConfigureAwait(false);
         }
 

--- a/src/ElCamino.AspNetCore.Identity.AzureTable/RoleStore.cs
+++ b/src/ElCamino.AspNetCore.Identity.AzureTable/RoleStore.cs
@@ -144,7 +144,7 @@ namespace ElCamino.AspNetCore.Identity.AzureTable
             ThrowIfDisposed();
 
             return await _roleTable.GetEntityOrDefaultAsync<TRole>(_keyHelper.GeneratePartitionKeyIdentityRole(roleName),
-            _keyHelper.GenerateRowKeyIdentityRole(roleName), cancellationToken: cancellationToken).ConfigureAwait(false);
+            _keyHelper.GenerateRowKeyIdentityRole(roleName).ToString(), cancellationToken: cancellationToken).ConfigureAwait(false);
         }
 
         /// <inheritdoc/>

--- a/src/ElCamino.AspNetCore.Identity.AzureTable/RoleStore.cs
+++ b/src/ElCamino.AspNetCore.Identity.AzureTable/RoleStore.cs
@@ -127,10 +127,8 @@ namespace ElCamino.AspNetCore.Identity.AzureTable
             }
         }
 
-#pragma warning disable CS8609 // Nullability of reference types in return type doesn't match overridden member.
         /// <inheritdoc/>
         public override async Task<TRole?> FindByIdAsync(string roleId, CancellationToken cancellationToken = default)
-#pragma warning restore CS8609 // Nullability of reference types in return type doesn't match overridden member.
         {
             cancellationToken.ThrowIfCancellationRequested();
             ThrowIfDisposed();
@@ -139,10 +137,8 @@ namespace ElCamino.AspNetCore.Identity.AzureTable
                 roleId.ToString(), cancellationToken: cancellationToken).ConfigureAwait(false);
         }
 
-#pragma warning disable CS8609 // Nullability of reference types in return type doesn't match overridden member.
         /// <inheritdoc/>
         public override async Task<TRole?> FindByNameAsync(string roleName, CancellationToken cancellationToken = default)
-#pragma warning restore CS8609 // Nullability of reference types in return type doesn't match overridden member.
         {
             cancellationToken.ThrowIfCancellationRequested();
             ThrowIfDisposed();
@@ -156,14 +152,8 @@ namespace ElCamino.AspNetCore.Identity.AzureTable
         {
             cancellationToken.ThrowIfCancellationRequested();
             ThrowIfDisposed();
-#if NET6_0_OR_GREATER
             ArgumentNullException.ThrowIfNull(role);
-#else
-            if (role is null)
-            {
-                throw new ArgumentNullException(nameof(role));
-            }
-#endif
+
             Model.IGenerateKeys? g = role as Model.IGenerateKeys;
             if (g is not null && !g.PeekRowKey(_keyHelper).Equals(role.RowKey, StringComparison.Ordinal))
             {

--- a/src/ElCamino.AspNetCore.Identity.AzureTable/RoleStore.cs
+++ b/src/ElCamino.AspNetCore.Identity.AzureTable/RoleStore.cs
@@ -69,7 +69,7 @@ namespace ElCamino.AspNetCore.Identity.AzureTable
             FilterString = TableQuery.CombineFilters(
                 TableQuery.GenerateFilterCondition(nameof(TableEntity.RowKey), QueryComparisons.GreaterThanOrEqual, _keyHelper.PreFixIdentityRole),
                 TableOperators.And,
-                TableQuery.GenerateFilterCondition(nameof(TableEntity.RowKey), QueryComparisons.LessThan, _keyHelper.PreFixIdentityRoleUpperBound));
+                TableQuery.GenerateFilterCondition(nameof(TableEntity.RowKey), QueryComparisons.LessThan, _keyHelper.PreFixIdentityRoleUpperBound)).ToString();
 
         }
 
@@ -205,13 +205,13 @@ namespace ElCamino.AspNetCore.Identity.AzureTable
                 throw new ArgumentNullException(nameof(role));
             }
 #endif
-            string partitionFilter = TableQuery.GenerateFilterCondition(nameof(TableEntity.PartitionKey), QueryComparisons.Equal, role.Id.ToString() ?? string.Empty);
+            var partitionFilter = TableQuery.GenerateFilterCondition(nameof(TableEntity.PartitionKey), QueryComparisons.Equal, role.Id.ToString() ?? string.Empty);
 
-            string rowFilter1 = TableQuery.GenerateFilterCondition(nameof(TableEntity.RowKey), QueryComparisons.GreaterThanOrEqual, _keyHelper.PreFixIdentityUserToken);
-            string rowFilter2 = TableQuery.GenerateFilterCondition(nameof(TableEntity.RowKey), QueryComparisons.LessThan, _keyHelper.PreFixIdentityUserId);
-            string rowFilter = TableQuery.CombineFilters(rowFilter1, TableOperators.Or, rowFilter2);
+            var rowFilter1 = TableQuery.GenerateFilterCondition(nameof(TableEntity.RowKey), QueryComparisons.GreaterThanOrEqual, _keyHelper.PreFixIdentityUserToken);
+            var rowFilter2 = TableQuery.GenerateFilterCondition(nameof(TableEntity.RowKey), QueryComparisons.LessThan, _keyHelper.PreFixIdentityUserId);
+            var rowFilter = TableQuery.CombineFilters(rowFilter1, TableOperators.Or, rowFilter2);
 
-            string filter = TableQuery.CombineFilters(partitionFilter, TableOperators.And, rowFilter);
+            var filter = TableQuery.CombineFilters(partitionFilter, TableOperators.And, rowFilter).ToString();
 
             return
 

--- a/src/ElCamino.AspNetCore.Identity.AzureTable/UserOnlyStore.cs
+++ b/src/ElCamino.AspNetCore.Identity.AzureTable/UserOnlyStore.cs
@@ -278,9 +278,9 @@ namespace ElCamino.AspNetCore.Identity.AzureTable
             ThrowIfDisposed();
 
             string rowKey = _keyHelper.GenerateRowKeyIdentityUserLogin(loginProvider, providerKey);
-            string partitionKey = _keyHelper.GeneratePartitionKeyIndexByLogin(loginProvider, providerKey);
+            var partitionKey = _keyHelper.GeneratePartitionKeyIndexByLogin(loginProvider, providerKey);
 
-            IdentityUserIndex? indexInfo = await _indexTable.GetEntityOrDefaultAsync<IdentityUserIndex>(partitionKey, rowKey, IndexUserIdSelectColumns, cancellationToken)
+            IdentityUserIndex? indexInfo = await _indexTable.GetEntityOrDefaultAsync<IdentityUserIndex>(partitionKey.ToString(), rowKey, IndexUserIdSelectColumns, cancellationToken)
                 .ConfigureAwait(false);
 
             if (indexInfo is not null && indexInfo.Id is not null)
@@ -305,9 +305,9 @@ namespace ElCamino.AspNetCore.Identity.AzureTable
             ThrowIfDisposed();
 
             string rowKey = _keyHelper.GenerateRowKeyIdentityUserLogin(loginProvider, providerKey);
-            string partitionKey = _keyHelper.GeneratePartitionKeyIndexByLogin(loginProvider, providerKey);
+            var partitionKey = _keyHelper.GeneratePartitionKeyIndexByLogin(loginProvider, providerKey);
 
-            return GetUserFromIndexQueryAsync(GetUserIdByIndexQuery(partitionKey, rowKey).ToString(), cancellationToken);
+            return GetUserFromIndexQueryAsync(GetUserIdByIndexQuery(partitionKey.ToString(), rowKey).ToString(), cancellationToken);
         }
 
         /// <inheritdoc/>
@@ -1157,7 +1157,7 @@ namespace ElCamino.AspNetCore.Identity.AzureTable
             return new Model.IdentityUserIndex()
             {
                 Id = userPartitionKey,
-                PartitionKey = _keyHelper.GeneratePartitionKeyIndexByLogin(loginProvider, providerKey),
+                PartitionKey = _keyHelper.GeneratePartitionKeyIndexByLogin(loginProvider, providerKey).ToString(),
                 RowKey = _keyHelper.GenerateRowKeyIdentityUserLogin(loginProvider, providerKey),
                 KeyVersion = _keyHelper.KeyVersion,
                 ETag = TableConstants.ETagWildcard

--- a/src/ElCamino.AspNetCore.Identity.AzureTable/UserOnlyStore.cs
+++ b/src/ElCamino.AspNetCore.Identity.AzureTable/UserOnlyStore.cs
@@ -960,6 +960,7 @@ namespace ElCamino.AspNetCore.Identity.AzureTable
             var token = await FindTokenAsync(user, loginProvider, name, cancellationToken);
 
             token ??= CreateUserToken(user, loginProvider, name, value);
+            token.Value = value;
 
             await AddUserTokenAsync(token);
         }

--- a/src/ElCamino.AspNetCore.Identity.AzureTable/UserOnlyStore.cs
+++ b/src/ElCamino.AspNetCore.Identity.AzureTable/UserOnlyStore.cs
@@ -955,11 +955,7 @@ namespace ElCamino.AspNetCore.Identity.AzureTable
             cancellationToken.ThrowIfCancellationRequested();
             ThrowIfDisposed();
 
-#if NET6_0_OR_GREATER
             ArgumentNullException.ThrowIfNull(user);
-#else
-            if (user is null) throw new ArgumentNullException(nameof(user));
-#endif
 
             var token = await FindTokenAsync(user, loginProvider, name, cancellationToken);
 

--- a/src/ElCamino.AspNetCore.Identity.AzureTable/UserOnlyStore.cs
+++ b/src/ElCamino.AspNetCore.Identity.AzureTable/UserOnlyStore.cs
@@ -419,7 +419,7 @@ namespace ElCamino.AspNetCore.Identity.AzureTable
         protected async Task<TUserClaim?> GetUserClaimAsync(TUser user, Claim claim)
         {
             return await _userTable.GetEntityOrDefaultAsync<TUserClaim>(_keyHelper.GenerateRowKeyUserId(ConvertIdToString(user.Id)).ToString(),
-                _keyHelper.GenerateRowKeyIdentityUserClaim(claim.Type, claim.Value)).ConfigureAwait(false);
+                _keyHelper.GenerateRowKeyIdentityUserClaim(claim.Type, claim.Value).ToString()).ConfigureAwait(false);
         }
 
         /// <inheritdoc/>
@@ -1081,7 +1081,7 @@ namespace ElCamino.AspNetCore.Identity.AzureTable
             return new Model.IdentityUserIndex()
             {
                 Id = userPartitionKey.ToString(),
-                PartitionKey = _keyHelper.GenerateRowKeyIdentityUserClaim(claimType, claimValue),
+                PartitionKey = _keyHelper.GenerateRowKeyIdentityUserClaim(claimType, claimValue).ToString(),
                 RowKey = userPartitionKey.ToString(),
                 KeyVersion = _keyHelper.KeyVersion,
                 ETag = TableConstants.ETagWildcard

--- a/src/ElCamino.AspNetCore.Identity.AzureTable/UserOnlyStore.cs
+++ b/src/ElCamino.AspNetCore.Identity.AzureTable/UserOnlyStore.cs
@@ -440,7 +440,7 @@ namespace ElCamino.AspNetCore.Identity.AzureTable
             await foreach (var tclaim in _userTable.QueryAsync<TUserClaim>(filter: filterString.ToString(), cancellationToken: cancellationToken).ConfigureAwait(false))
             {
                 //1.7 Claim rowkey migration 
-                if (_keyHelper.GenerateRowKeyIdentityUserClaim(tclaim.ClaimType, tclaim.ClaimValue) == tclaim.RowKey)
+                if (_keyHelper.GenerateRowKeyIdentityUserClaim(tclaim.ClaimType, tclaim.ClaimValue).Equals(tclaim.RowKey.AsSpan(), StringComparison.OrdinalIgnoreCase))
                 {
                     rClaims.Add(tclaim.ToClaim());
                 }
@@ -1188,7 +1188,7 @@ namespace ElCamino.AspNetCore.Identity.AzureTable
             {
                 return GetUserAggregateQueryAsync(userId, setFilterByUserId: getTableQueryFilterByUserId, whereClaim: (uc) =>
                 {
-                    return uc.RowKey == _keyHelper.GenerateRowKeyIdentityUserClaim(claim.Type, claim.Value);
+                    return uc.RowKey.AsSpan().Equals(_keyHelper.GenerateRowKeyIdentityUserClaim(claim.Type, claim.Value), StringComparison.OrdinalIgnoreCase);
                 }, cancellationToken);
 
             }, cancellationToken).ConfigureAwait(false)).ToList();
@@ -1213,7 +1213,7 @@ namespace ElCamino.AspNetCore.Identity.AzureTable
         protected override async Task<TUserToken?> FindTokenAsync(TUser user, string loginProvider, string name, CancellationToken cancellationToken)
         {
             return await _userTable.GetEntityOrDefaultAsync<TUserToken>(_keyHelper.GenerateRowKeyUserId(ConvertIdToString(user.Id)).ToString(),
-                    _keyHelper.GenerateRowKeyIdentityUserToken(loginProvider, name), cancellationToken: cancellationToken).ConfigureAwait(false);
+                    _keyHelper.GenerateRowKeyIdentityUserToken(loginProvider, name).ToString(), cancellationToken: cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>

--- a/src/ElCamino.AspNetCore.Identity.AzureTable/UserOnlyStore.cs
+++ b/src/ElCamino.AspNetCore.Identity.AzureTable/UserOnlyStore.cs
@@ -264,9 +264,9 @@ namespace ElCamino.AspNetCore.Identity.AzureTable
         {
             if (userId is not null)
             {
-                string rowKey = _keyHelper.GenerateRowKeyIdentityUserLogin(loginProvider, providerKey);
+                var rowKey = _keyHelper.GenerateRowKeyIdentityUserLogin(loginProvider, providerKey);
 
-                return await _userTable.GetEntityOrDefaultAsync<TUserLogin>(userId!, rowKey).ConfigureAwait(false);
+                return await _userTable.GetEntityOrDefaultAsync<TUserLogin>(userId!, rowKey.ToString()).ConfigureAwait(false);
             }
             return default;
         }
@@ -277,16 +277,15 @@ namespace ElCamino.AspNetCore.Identity.AzureTable
             cancellationToken.ThrowIfCancellationRequested();
             ThrowIfDisposed();
 
-            string rowKey = _keyHelper.GenerateRowKeyIdentityUserLogin(loginProvider, providerKey);
+            var rowKey = _keyHelper.GenerateRowKeyIdentityUserLogin(loginProvider, providerKey);
             var partitionKey = _keyHelper.GeneratePartitionKeyIndexByLogin(loginProvider, providerKey);
 
-            IdentityUserIndex? indexInfo = await _indexTable.GetEntityOrDefaultAsync<IdentityUserIndex>(partitionKey.ToString(), rowKey, IndexUserIdSelectColumns, cancellationToken)
+            IdentityUserIndex? indexInfo = await _indexTable.GetEntityOrDefaultAsync<IdentityUserIndex>(partitionKey.ToString(), rowKey.ToString(), IndexUserIdSelectColumns, cancellationToken)
                 .ConfigureAwait(false);
 
             if (indexInfo is not null && indexInfo.Id is not null)
             {
-                string userId = indexInfo.Id;
-                return await FindUserLoginAsync(userId, loginProvider, providerKey).ConfigureAwait(false);
+                return await FindUserLoginAsync(indexInfo.Id, loginProvider, providerKey).ConfigureAwait(false);
             }
 
             return null;
@@ -304,10 +303,10 @@ namespace ElCamino.AspNetCore.Identity.AzureTable
             cancellationToken.ThrowIfCancellationRequested();
             ThrowIfDisposed();
 
-            string rowKey = _keyHelper.GenerateRowKeyIdentityUserLogin(loginProvider, providerKey);
+            var rowKey = _keyHelper.GenerateRowKeyIdentityUserLogin(loginProvider, providerKey);
             var partitionKey = _keyHelper.GeneratePartitionKeyIndexByLogin(loginProvider, providerKey);
 
-            return GetUserFromIndexQueryAsync(GetUserIdByIndexQuery(partitionKey.ToString(), rowKey).ToString(), cancellationToken);
+            return GetUserFromIndexQueryAsync(GetUserIdByIndexQuery(partitionKey.ToString(), rowKey.ToString()).ToString(), cancellationToken);
         }
 
         /// <inheritdoc/>
@@ -1156,7 +1155,7 @@ namespace ElCamino.AspNetCore.Identity.AzureTable
             {
                 Id = userPartitionKey,
                 PartitionKey = _keyHelper.GeneratePartitionKeyIndexByLogin(loginProvider, providerKey).ToString(),
-                RowKey = _keyHelper.GenerateRowKeyIdentityUserLogin(loginProvider, providerKey),
+                RowKey = _keyHelper.GenerateRowKeyIdentityUserLogin(loginProvider, providerKey).ToString(),
                 KeyVersion = _keyHelper.KeyVersion,
                 ETag = TableConstants.ETagWildcard
             };

--- a/src/ElCamino.AspNetCore.Identity.AzureTable/UserOnlyStore.cs
+++ b/src/ElCamino.AspNetCore.Identity.AzureTable/UserOnlyStore.cs
@@ -1005,7 +1005,7 @@ namespace ElCamino.AspNetCore.Identity.AzureTable
                 !string.IsNullOrWhiteSpace(userId))
             {
                 string userPartitionKey = _keyHelper.GenerateRowKeyUserId(userId);
-                var result = await _indexTable.GetEntityOrDefaultAsync<IdentityUserIndex>(_keyHelper.GenerateRowKeyUserName(userName), userPartitionKey).ConfigureAwait(false);
+                var result = await _indexTable.GetEntityOrDefaultAsync<IdentityUserIndex>(_keyHelper.GenerateRowKeyUserName(userName).ToString(), userPartitionKey).ConfigureAwait(false);
                 if (result is not null)
                 {
                     _ = await _indexTable.DeleteEntityAsync(result.PartitionKey, result.RowKey, TableConstants.ETagWildcard).ConfigureAwait(false);
@@ -1138,7 +1138,7 @@ namespace ElCamino.AspNetCore.Identity.AzureTable
             return new Model.IdentityUserIndex()
             {
                 Id = userPartitionKey,
-                PartitionKey = _keyHelper.GenerateRowKeyUserName(userName),
+                PartitionKey = _keyHelper.GenerateRowKeyUserName(userName).ToString(),
                 RowKey = userPartitionKey,
                 KeyVersion = _keyHelper.KeyVersion,
                 ETag = TableConstants.ETagWildcard

--- a/src/ElCamino.AspNetCore.Identity.AzureTable/UserOnlyStore.cs
+++ b/src/ElCamino.AspNetCore.Identity.AzureTable/UserOnlyStore.cs
@@ -324,7 +324,7 @@ namespace ElCamino.AspNetCore.Identity.AzureTable
             cancellationToken.ThrowIfCancellationRequested();
             ThrowIfDisposed();
             IEnumerable<TUser> users = await GetUsersByIndexQueryAsync(FindByEmailIndexQuery(plainEmail).ToString(), GetUserQueryAsync, cancellationToken).ConfigureAwait(false);
-            return users.Where(user => _keyHelper.GenerateRowKeyUserEmail(plainEmail) == _keyHelper.GenerateRowKeyUserEmail(user.Email));
+            return users.Where(user => _keyHelper.GenerateRowKeyUserEmail(plainEmail).Equals(_keyHelper.GenerateRowKeyUserEmail(user.Email), StringComparison.InvariantCultureIgnoreCase));
         }
 
         /// <inheritdoc/>
@@ -386,7 +386,7 @@ namespace ElCamino.AspNetCore.Identity.AzureTable
         /// </summary>
         /// <param name="partitionKey"></param>
         /// <returns>Odata filter query</returns>
-        protected ReadOnlySpan<char> GetUserIdsByIndexQuery(string partitionKey)
+        protected ReadOnlySpan<char> GetUserIdsByIndexQuery(ReadOnlySpan<char> partitionKey)
         {
             return TableQuery.GenerateFilterCondition(nameof(TableEntity.PartitionKey), QueryComparisons.Equal, partitionKey);
         }
@@ -1120,7 +1120,7 @@ namespace ElCamino.AspNetCore.Identity.AzureTable
             return new Model.IdentityUserIndex()
             {
                 Id = userid,
-                PartitionKey = _keyHelper.GenerateRowKeyUserEmail(email),
+                PartitionKey = _keyHelper.GenerateRowKeyUserEmail(email).ToString(),
                 RowKey = userid,
                 KeyVersion = _keyHelper.KeyVersion,
                 ETag = TableConstants.ETagWildcard

--- a/src/ElCamino.AspNetCore.Identity.AzureTable/UserOnlyStore.cs
+++ b/src/ElCamino.AspNetCore.Identity.AzureTable/UserOnlyStore.cs
@@ -63,7 +63,7 @@ namespace ElCamino.AspNetCore.Identity.AzureTable
         private readonly TContext _context;
 
         private readonly string FilterString;
-        private static readonly List<string> IndexUserIdSelectColumns = new() { nameof(IdentityUserIndex.Id) };
+        private static readonly List<string> IndexUserIdSelectColumns = [nameof(IdentityUserIndex.Id)];
 
         /// <inheritdoc/>
         public UserOnlyStore(TContext context, IKeyHelper keyHelper) : base(new IdentityErrorDescriber())
@@ -101,11 +101,11 @@ namespace ElCamino.AspNetCore.Identity.AzureTable
         /// <returns></returns>
         public virtual Task CreateTablesIfNotExistsAsync()
         {
-            Task[] tasks = new Task[]
-                    {
+            Task[] tasks =
+                    [
                         _userTable.CreateIfNotExistsAsync(),
                         _indexTable.CreateIfNotExistsAsync(),
-                    };
+                    ];
             return Task.WhenAll(tasks);
         }
 
@@ -114,12 +114,12 @@ namespace ElCamino.AspNetCore.Identity.AzureTable
         {
             cancellationToken.ThrowIfCancellationRequested();
             ThrowIfDisposed();
-            if (user is null) throw new ArgumentNullException(nameof(user));
-            if (claims is null) throw new ArgumentNullException(nameof(claims));
+            ArgumentNullException.ThrowIfNull(user);
+            ArgumentNullException.ThrowIfNull(claims);
 
             BatchOperationHelper bHelper = new BatchOperationHelper(_userTable);
 
-            List<Task> tasks = new List<Task>();
+            List<Task> tasks = [];
             string userPartitionKey = _keyHelper.GenerateRowKeyUserId(ConvertIdToString(user.Id));
             foreach (Claim c in claims)
             {
@@ -135,14 +135,14 @@ namespace ElCamino.AspNetCore.Identity.AzureTable
         public virtual async Task AddClaimAsync(TUser user, Claim claim)
         {
             ThrowIfDisposed();
-            if (user is null) throw new ArgumentNullException(nameof(user));
-            if (claim is null) throw new ArgumentNullException(nameof(claim));
+            ArgumentNullException.ThrowIfNull(user);
+            ArgumentNullException.ThrowIfNull(claim);
 
-            List<Task> tasks = new List<Task>(2)
-            {
+            List<Task> tasks =
+            [
                 _userTable.AddEntityAsync(CreateUserClaim(user, claim)),
                 _indexTable.UpsertEntityAsync(CreateClaimIndex(_keyHelper.GenerateRowKeyUserId(ConvertIdToString(user.Id)), claim.Type, claim.Value), mode: TableUpdateMode.Replace)
-            };
+            ];
 
             await Task.WhenAll(tasks).ConfigureAwait(false);
         }
@@ -152,8 +152,8 @@ namespace ElCamino.AspNetCore.Identity.AzureTable
         {
             cancellationToken.ThrowIfCancellationRequested();
             ThrowIfDisposed();
-            if (user is null) throw new ArgumentNullException(nameof(user));
-            if (login is null) throw new ArgumentNullException(nameof(login));
+            ArgumentNullException.ThrowIfNull(user);
+            ArgumentNullException.ThrowIfNull(login);
 
             TUserLogin item = CreateUserLogin(user, login);
 
@@ -168,7 +168,7 @@ namespace ElCamino.AspNetCore.Identity.AzureTable
         {
             cancellationToken.ThrowIfCancellationRequested();
             ThrowIfDisposed();
-            if (user is null) throw new ArgumentNullException(nameof(user));
+            ArgumentNullException.ThrowIfNull(user);
 
             ((Model.IGenerateKeys)user).GenerateKeys(_keyHelper);
 
@@ -191,7 +191,7 @@ namespace ElCamino.AspNetCore.Identity.AzureTable
                     tasks.Add(_indexTable.UpsertEntityAsync(index, mode: TableUpdateMode.Replace, cancellationToken: cancellationToken));
                 }
 
-                await Task.WhenAll(tasks.ToArray()).ConfigureAwait(false);
+                await Task.WhenAll([.. tasks]).ConfigureAwait(false);
                 return IdentityResult.Success;
             }
             catch (AggregateException aggex)
@@ -206,7 +206,7 @@ namespace ElCamino.AspNetCore.Identity.AzureTable
         {
             cancellationToken.ThrowIfCancellationRequested();
             ThrowIfDisposed();
-            if (user is null) throw new ArgumentNullException(nameof(user));
+            ArgumentNullException.ThrowIfNull(user);
 
             List<Task> tasks = new List<Task>(50);
             string userPartitionKey = _keyHelper.GenerateRowKeyUserId(ConvertIdToString(user.Id));
@@ -241,7 +241,7 @@ namespace ElCamino.AspNetCore.Identity.AzureTable
 
             try
             {
-                await Task.WhenAll(tasks.ToArray()).ConfigureAwait(false);
+                await Task.WhenAll([.. tasks]).ConfigureAwait(false);
                 return IdentityResult.Success;
             }
             catch (AggregateException aggex)
@@ -251,10 +251,8 @@ namespace ElCamino.AspNetCore.Identity.AzureTable
             }
         }
 
-#pragma warning disable CS8609 // Nullability of reference types in return type doesn't match overridden member.
         /// <inheritdoc/>
         protected override Task<TUserLogin?> FindUserLoginAsync(TKey userId, string loginProvider, string providerKey, CancellationToken cancellationToken)
-#pragma warning restore CS8609 // Nullability of reference types in return type doesn't match overridden member.
         {
             cancellationToken.ThrowIfCancellationRequested();
             ThrowIfDisposed();
@@ -273,10 +271,8 @@ namespace ElCamino.AspNetCore.Identity.AzureTable
             return default;
         }
 
-#pragma warning disable CS8609 // Nullability of reference types in return type doesn't match overridden member.
         /// <inheritdoc/>
         protected override async Task<TUserLogin?> FindUserLoginAsync(string loginProvider, string providerKey, CancellationToken cancellationToken)
-#pragma warning restore CS8609 // Nullability of reference types in return type doesn't match overridden member.
         {
             cancellationToken.ThrowIfCancellationRequested();
             ThrowIfDisposed();
@@ -303,9 +299,7 @@ namespace ElCamino.AspNetCore.Identity.AzureTable
         /// <param name="providerKey"></param>
         /// <param name="cancellationToken"></param>
         /// <returns></returns>
-#pragma warning disable CS8609 // Nullability of reference types in return type doesn't match overridden member.
         public override Task<TUser?> FindByLoginAsync(string loginProvider, string providerKey, CancellationToken cancellationToken = default)
-#pragma warning restore CS8609 // Nullability of reference types in return type doesn't match overridden member.
         {
             cancellationToken.ThrowIfCancellationRequested();
             ThrowIfDisposed();
@@ -316,10 +310,8 @@ namespace ElCamino.AspNetCore.Identity.AzureTable
             return GetUserFromIndexQueryAsync(GetUserIdByIndexQuery(partitionKey, rowKey).ToString(), cancellationToken);
         }
 
-#pragma warning disable CS8609 // Nullability of reference types in return type doesn't match overridden member.
         /// <inheritdoc/>
         public override Task<TUser?> FindByEmailAsync(string plainEmail, CancellationToken cancellationToken = default)
-#pragma warning restore CS8609 // Nullability of reference types in return type doesn't match overridden member.
         {
             cancellationToken.ThrowIfCancellationRequested();
             ThrowIfDisposed();
@@ -335,10 +327,8 @@ namespace ElCamino.AspNetCore.Identity.AzureTable
             return users.Where(user => _keyHelper.GenerateRowKeyUserEmail(plainEmail) == _keyHelper.GenerateRowKeyUserEmail(user.Email));
         }
 
-#pragma warning disable CS8609 // Nullability of reference types in return type doesn't match overridden member.
         /// <inheritdoc/>
         protected override Task<TUser?> FindUserAsync(TKey userId, CancellationToken cancellationToken)
-#pragma warning restore CS8609 // Nullability of reference types in return type doesn't match overridden member.
         {
             cancellationToken.ThrowIfCancellationRequested();
             ThrowIfDisposed();
@@ -401,20 +391,16 @@ namespace ElCamino.AspNetCore.Identity.AzureTable
             return TableQuery.GenerateFilterCondition(nameof(TableEntity.PartitionKey), QueryComparisons.Equal, partitionKey);
         }
 
-#pragma warning disable CS8609 // Nullability of reference types in return type doesn't match overridden member.
         /// <inheritdoc/>
         public override Task<TUser?> FindByIdAsync(string userId, CancellationToken cancellationToken = default)
-#pragma warning restore CS8609 // Nullability of reference types in return type doesn't match overridden member.
         {
             cancellationToken.ThrowIfCancellationRequested();
             ThrowIfDisposed();
             return GetUserAsync(_keyHelper.GenerateRowKeyUserId(userId), cancellationToken);
         }
 
-#pragma warning disable CS8609 // Nullability of reference types in return type doesn't match overridden member.
         /// <inheritdoc/>
         public override async Task<TUser?> FindByNameAsync(string normalizedUserName, CancellationToken cancellationToken = default)
-#pragma warning restore CS8609 // Nullability of reference types in return type doesn't match overridden member.
         {
             cancellationToken.ThrowIfCancellationRequested();
             ThrowIfDisposed();
@@ -441,8 +427,8 @@ namespace ElCamino.AspNetCore.Identity.AzureTable
         {
             cancellationToken.ThrowIfCancellationRequested();
             ThrowIfDisposed();
-            if (user is null) throw new ArgumentNullException(nameof(user));
-            List<Claim> rClaims = new List<Claim>();
+            ArgumentNullException.ThrowIfNull(user);
+            List<Claim> rClaims = [];
 
             var partitionFilter =
                 TableQuery.GenerateFilterCondition(nameof(TableEntity.PartitionKey), QueryComparisons.Equal, user.PartitionKey);
@@ -468,9 +454,9 @@ namespace ElCamino.AspNetCore.Identity.AzureTable
         {
             cancellationToken.ThrowIfCancellationRequested();
             ThrowIfDisposed();
-            if (user is null) throw new ArgumentNullException(nameof(user));
+            ArgumentNullException.ThrowIfNull(user);
 
-            List<UserLoginInfo> rLogins = new List<UserLoginInfo>();
+            List<UserLoginInfo> rLogins = [];
 
             var partitionFilter =
                 TableQuery.GenerateFilterCondition(nameof(TableEntity.PartitionKey), QueryComparisons.Equal, user.PartitionKey);
@@ -573,7 +559,7 @@ namespace ElCamino.AspNetCore.Identity.AzureTable
 
             }
 
-            ConcurrentBag<TUser> bag = new ConcurrentBag<TUser>();
+            ConcurrentBag<TUser> bag = [];
 #if DEBUG
             DateTime startUserAggTotal = DateTime.UtcNow;
 #endif
@@ -624,7 +610,7 @@ namespace ElCamino.AspNetCore.Identity.AzureTable
             const double pageSize = 50.0;
             int pages = (int)Math.Ceiling(((double)userIds.Count() / pageSize));
             List<string> listTqs = new List<string>(pages);
-            IEnumerable<string> tempUserIds = Enumerable.Empty<string>();
+            IEnumerable<string> tempUserIds = [];
 
             for (int currentPage = 1; currentPage <= pages; currentPage++)
             {
@@ -662,7 +648,7 @@ namespace ElCamino.AspNetCore.Identity.AzureTable
 
             }
 
-            ConcurrentBag<TUser> bag = new ConcurrentBag<TUser>();
+            ConcurrentBag<TUser> bag = [];
 #if DEBUG
             DateTime startUserAggTotal = DateTime.UtcNow;
 #endif
@@ -693,9 +679,9 @@ namespace ElCamino.AspNetCore.Identity.AzureTable
         {
 
             TUser? user = default;
-            IEnumerable<TUserClaim> claims = Enumerable.Empty<TUserClaim>();
-            IEnumerable<TUserLogin> logins = Enumerable.Empty<TUserLogin>();
-            IEnumerable<TUserToken> tokens = Enumerable.Empty<TUserToken>();
+            IEnumerable<TUserClaim> claims = [];
+            IEnumerable<TUserLogin> logins = [];
+            IEnumerable<TUserToken> tokens = [];
 
             var vUser = userResults.Where(u => u.RowKey.Equals(userId) && u.PartitionKey.Equals(userId)).SingleOrDefault();
 
@@ -763,7 +749,7 @@ namespace ElCamino.AspNetCore.Identity.AzureTable
 #if DEBUG
             DateTime startIndex = DateTime.UtcNow;
 #endif
-            ConcurrentBag<IEnumerable<TUser>> lUsers = new ConcurrentBag<IEnumerable<TUser>>();
+            ConcurrentBag<IEnumerable<TUser>> lUsers = [];
             string? token = string.Empty;
             const int takeCount = 30;
             const int taskMax = 10;
@@ -776,7 +762,7 @@ namespace ElCamino.AspNetCore.Identity.AzureTable
             {
                 IAsyncEnumerable<Page<IdentityUserIndex>> pages = _indexTable.QueryAsync<IdentityUserIndex>(indexQuery, takeCount, IndexUserIdSelectColumns, cancellationToken).AsPages(continuationToken: token);
                 Page<IdentityUserIndex>? page = await pages.FirstOrDefaultAsync(cancellationToken).ConfigureAwait(false);
-                IEnumerable<string> tempUserIds = page?.Values.Where(w => !string.IsNullOrWhiteSpace(w.Id)).Select(u => u.Id!).Distinct() ?? Enumerable.Empty<string>();
+                IEnumerable<string> tempUserIds = page?.Values.Where(w => !string.IsNullOrWhiteSpace(w.Id)).Select(u => u.Id!).Distinct() ?? [];
                 taskBatch.Add(getUsers(tempUserIds, cancellationToken));
                 if (taskBatch.Count % taskMax == 0)
                 {
@@ -802,8 +788,8 @@ namespace ElCamino.AspNetCore.Identity.AzureTable
         public virtual async Task RemoveClaimAsync(TUser user, Claim claim)
         {
             ThrowIfDisposed();
-            if (user is null) throw new ArgumentNullException(nameof(user));
-            if (claim is null) throw new ArgumentNullException(nameof(claim));
+            ArgumentNullException.ThrowIfNull(user);
+            ArgumentNullException.ThrowIfNull(claim);
 
             // Claim ctor doesn't allow Claim.Value to be null. Need to allow string.empty.
 
@@ -830,9 +816,9 @@ namespace ElCamino.AspNetCore.Identity.AzureTable
         {
             cancellationToken.ThrowIfCancellationRequested();
             ThrowIfDisposed();
-            if (user is null) throw new ArgumentNullException(nameof(user));
-            if (claim is null) throw new ArgumentNullException(nameof(claim));
-            if (newClaim is null) throw new ArgumentNullException(nameof(newClaim));
+            ArgumentNullException.ThrowIfNull(user);
+            ArgumentNullException.ThrowIfNull(claim);
+            ArgumentNullException.ThrowIfNull(newClaim);
 
             // Claim ctor doesn't allow Claim.Value to be null. Need to allow string.empty.
             BatchOperationHelper bHelper = new BatchOperationHelper(_userTable);
@@ -862,11 +848,11 @@ namespace ElCamino.AspNetCore.Identity.AzureTable
         {
             cancellationToken.ThrowIfCancellationRequested();
             ThrowIfDisposed();
-            if (user is null) throw new ArgumentNullException(nameof(user));
-            if (claims is null) throw new ArgumentNullException(nameof(claims));
+            ArgumentNullException.ThrowIfNull(user);
+            ArgumentNullException.ThrowIfNull(claims);
 
             // Claim ctor doesn't allow Claim.Value to be null. Need to allow string.empty.
-            List<Task> tasks = new List<Task>();
+            List<Task> tasks = [];
             string userPartitionKey = _keyHelper.GenerateRowKeyUserId(ConvertIdToString(user.Id));
             BatchOperationHelper bHelper = new BatchOperationHelper(_userTable);
             var userClaims = await GetClaimsAsync(user, cancellationToken).ConfigureAwait(false);
@@ -914,7 +900,7 @@ namespace ElCamino.AspNetCore.Identity.AzureTable
         {
             cancellationToken.ThrowIfCancellationRequested();
             ThrowIfDisposed();
-            if (user is null) throw new ArgumentNullException(nameof(user));
+            ArgumentNullException.ThrowIfNull(user);
             string userPartitionKey = _keyHelper.GenerateRowKeyUserId(ConvertIdToString(user.Id));
             TUserLogin? item = await FindUserLoginAsync(userPartitionKey, loginProvider, providerKey).ConfigureAwait(false);
 
@@ -931,7 +917,7 @@ namespace ElCamino.AspNetCore.Identity.AzureTable
         {
             cancellationToken.ThrowIfCancellationRequested();
             ThrowIfDisposed();
-            if (user is null) throw new ArgumentNullException(nameof(user));
+            ArgumentNullException.ThrowIfNull(user);
 
             //Only remove the username if different
             //The UserManager calls UpdateAsync which will generate the new username index record
@@ -947,7 +933,7 @@ namespace ElCamino.AspNetCore.Identity.AzureTable
         {
             cancellationToken.ThrowIfCancellationRequested();
             ThrowIfDisposed();
-            if (user is null) throw new ArgumentNullException(nameof(user));
+            ArgumentNullException.ThrowIfNull(user);
 
             //Only remove the email if different
             //The UserManager calls UpdateAsync which will generate the new email index record
@@ -1052,7 +1038,7 @@ namespace ElCamino.AspNetCore.Identity.AzureTable
         {
             cancellationToken.ThrowIfCancellationRequested();
             ThrowIfDisposed();
-            if (user is null) throw new ArgumentNullException(nameof(user));
+            ArgumentNullException.ThrowIfNull(user);
             string userPartitionKey = _keyHelper.GenerateRowKeyUserId(ConvertIdToString(user.Id));
             List<Task> tasks = new List<Task>(3)
             {
@@ -1069,7 +1055,7 @@ namespace ElCamino.AspNetCore.Identity.AzureTable
 
             try
             {
-                await Task.WhenAll(tasks.ToArray()).ConfigureAwait(false);
+                await Task.WhenAll([.. tasks]).ConfigureAwait(false);
                 return IdentityResult.Success;
             }
             catch (AggregateException aggex)
@@ -1185,10 +1171,7 @@ namespace ElCamino.AspNetCore.Identity.AzureTable
             cancellationToken.ThrowIfCancellationRequested();
             ThrowIfDisposed();
 
-            if (claim is null)
-            {
-                throw new ArgumentNullException(nameof(claim));
-            }
+            ArgumentNullException.ThrowIfNull(claim);
 
             string getTableQueryFilterByUserId(string userId)
             {
@@ -1223,15 +1206,13 @@ namespace ElCamino.AspNetCore.Identity.AzureTable
         {
             cancellationToken.ThrowIfCancellationRequested();
             ThrowIfDisposed();
-            if (user is null) throw new ArgumentNullException(nameof(user));
+            ArgumentNullException.ThrowIfNull(user);
 
             return Task.FromResult(user.Id is not null ? user.Id.ToString()??string.Empty : string.Empty);
         }
 
-#pragma warning disable CS8609 // Nullability of reference types in return type doesn't match overridden member.
         /// <inheritdoc/>
         protected override async Task<TUserToken?> FindTokenAsync(TUser user, string loginProvider, string name, CancellationToken cancellationToken)
-#pragma warning restore CS8609 // Nullability of reference types in return type doesn't match overridden member.
         {
             return await _userTable.GetEntityOrDefaultAsync<TUserToken>(_keyHelper.GenerateRowKeyUserId(ConvertIdToString(user.Id)),
                     _keyHelper.GenerateRowKeyIdentityUserToken(loginProvider, name), cancellationToken: cancellationToken).ConfigureAwait(false);

--- a/src/ElCamino.AspNetCore.Identity.AzureTable/UserOnlyStore.cs
+++ b/src/ElCamino.AspNetCore.Identity.AzureTable/UserOnlyStore.cs
@@ -324,7 +324,7 @@ namespace ElCamino.AspNetCore.Identity.AzureTable
             cancellationToken.ThrowIfCancellationRequested();
             ThrowIfDisposed();
             IEnumerable<TUser> users = await GetUsersByIndexQueryAsync(FindByEmailIndexQuery(plainEmail).ToString(), GetUserQueryAsync, cancellationToken).ConfigureAwait(false);
-            return users.Where(user => _keyHelper.GenerateRowKeyUserEmail(plainEmail).Equals(_keyHelper.GenerateRowKeyUserEmail(user.Email), StringComparison.InvariantCultureIgnoreCase));
+            return users.Where(user => _keyHelper.GenerateRowKeyUserEmail(plainEmail).Equals(_keyHelper.GenerateRowKeyUserEmail(user.Email), StringComparison.OrdinalIgnoreCase));
         }
 
         /// <inheritdoc/>
@@ -1037,7 +1037,7 @@ namespace ElCamino.AspNetCore.Identity.AzureTable
             cancellationToken.ThrowIfCancellationRequested();
             ThrowIfDisposed();
             ArgumentNullException.ThrowIfNull(user);
-            var userPartitionKey = _keyHelper.GenerateRowKeyUserId(ConvertIdToString(user.Id));
+            string userPartitionKey = _keyHelper.GenerateRowKeyUserId(ConvertIdToString(user.Id)).ToString();
             List<Task> tasks = new List<Task>(3)
             {
                 _userTable.UpdateEntityAsync(user, TableConstants.ETagWildcard, mode: TableUpdateMode.Replace, cancellationToken),
@@ -1100,7 +1100,7 @@ namespace ElCamino.AspNetCore.Identity.AzureTable
             return new Model.IdentityUserIndex()
             {
                 Id = userPartitionKey,
-                PartitionKey = _keyHelper.GenerateRowKeyIdentityUserRole(plainRoleName),
+                PartitionKey = _keyHelper.GenerateRowKeyIdentityUserRole(plainRoleName).ToString(),
                 RowKey = userPartitionKey,
                 KeyVersion = _keyHelper.KeyVersion,
                 ETag = TableConstants.ETagWildcard

--- a/src/ElCamino.AspNetCore.Identity.AzureTable/UserStore.cs
+++ b/src/ElCamino.AspNetCore.Identity.AzureTable/UserStore.cs
@@ -15,9 +15,7 @@ namespace ElCamino.AspNetCore.Identity.AzureTable
 {
     /// <inheritdoc/>
     public class UserStore<TUser, TContext> : UserStore<TUser, Model.IdentityRole, string, Model.IdentityUserLogin, Model.IdentityUserRole, Model.IdentityUserClaim, Model.IdentityUserToken, TContext>
-#pragma warning disable CS8613 // Nullability of reference types in return type doesn't match implicitly implemented member.
        , IUserStore<TUser>
-#pragma warning restore CS8613 // Nullability of reference types in return type doesn't match implicitly implemented member.
        where TUser : Model.IdentityUser<string>, new()
        where TContext : IdentityCloudContext
     {
@@ -32,9 +30,7 @@ namespace ElCamino.AspNetCore.Identity.AzureTable
     /// <typeparam name="TRole"></typeparam>
     /// <typeparam name="TContext"></typeparam>
     public class UserStore<TUser, TRole, TContext> : UserStore<TUser, TRole, string, Model.IdentityUserLogin, Model.IdentityUserRole, Model.IdentityUserClaim, Model.IdentityUserToken, TContext>
-#pragma warning disable CS8613 // Nullability of reference types in return type doesn't match implicitly implemented member.
         , IUserStore<TUser>
-#pragma warning restore CS8613 // Nullability of reference types in return type doesn't match implicitly implemented member.
         where TUser : Model.IdentityUser<string>, new()
         where TRole : Model.IdentityRole<string, Model.IdentityUserRole>, new()
         where TContext : IdentityCloudContext
@@ -46,9 +42,7 @@ namespace ElCamino.AspNetCore.Identity.AzureTable
     /// <inheritdoc/>
     public class UserStore<TUser, TRole, TKey, TUserLogin, TUserRole, TUserClaim, TUserToken, TContext> :
         UserOnlyStore<TUser, TContext, TKey, TUserClaim, TUserLogin, TUserToken>
-#pragma warning disable CS8613 // Nullability of reference types in return type doesn't match implicitly implemented member.
         , IUserRoleStore<TUser>
-#pragma warning restore CS8613 // Nullability of reference types in return type doesn't match implicitly implemented member.
         , IDisposable
         where TUser : Model.IdentityUser<TKey>, new()
         where TRole : Model.IdentityRole<TKey, TUserRole>, new()
@@ -77,11 +71,10 @@ namespace ElCamino.AspNetCore.Identity.AzureTable
         public override Task CreateTablesIfNotExistsAsync()
         {
             Task[] tasks =
-                new Task[]
-                {
+                [
                     base.CreateTablesIfNotExistsAsync(),
                     _roleTable.CreateIfNotExistsAsync(),
-                };
+                ];
             return Task.WhenAll(tasks);
         }
 
@@ -90,7 +83,7 @@ namespace ElCamino.AspNetCore.Identity.AzureTable
         {
             cancellationToken.ThrowIfCancellationRequested();
             ThrowIfDisposed();
-            if (user is null) throw new ArgumentNullException(nameof(user));
+            ArgumentNullException.ThrowIfNull(user);
             if (string.IsNullOrWhiteSpace(roleName))
             {
                 throw new ArgumentException(IdentityResources.ValueCannotBeNullOrEmpty, nameof(roleName));
@@ -110,11 +103,11 @@ namespace ElCamino.AspNetCore.Identity.AzureTable
 
             ((Model.IGenerateKeys)item).GenerateKeys(_keyHelper);
 
-            List<Task> tasks = new List<Task>(2)
-            {
+            List<Task> tasks =
+            [
                 _userTable.AddEntityAsync(item, cancellationToken),
                 _indexTable.UpsertEntityAsync(CreateRoleIndex(userToRole.PartitionKey, roleName), mode: TableUpdateMode.Replace, cancellationToken: cancellationToken)
-            };
+            ];
 
             await Task.WhenAll(tasks).ConfigureAwait(false);
         }
@@ -123,12 +116,9 @@ namespace ElCamino.AspNetCore.Identity.AzureTable
         public virtual async Task<IList<string>> GetRolesAsync(TUser user, CancellationToken cancellationToken = default)
         {
             cancellationToken.ThrowIfCancellationRequested();
-            ConcurrentBag<string> bag = new ConcurrentBag<string>();
+            ConcurrentBag<string> bag = [];
             ThrowIfDisposed();
-            if (user is null)
-            {
-                throw new ArgumentNullException(nameof(user));
-            }
+            ArgumentNullException.ThrowIfNull(user);
 
             if (EqualityComparer<TKey?>.Default.Equals(user!.Id, default))
             {
@@ -179,7 +169,7 @@ namespace ElCamino.AspNetCore.Identity.AzureTable
                         iRoleCounter++;
                     }
                     tasks.Add(
-                        _roleTable.QueryAsync<Model.IdentityRole>(filter: queryTemp, select: new List<string>() { nameof(Model.IdentityRole.Name) }, cancellationToken: cancellationToken)
+                        _roleTable.QueryAsync<Model.IdentityRole>(filter: queryTemp, select: [nameof(Model.IdentityRole.Name)], cancellationToken: cancellationToken)
                         .ForEachAsync((t) =>
                         {
                             if (!string.IsNullOrWhiteSpace(t?.Name))
@@ -192,7 +182,7 @@ namespace ElCamino.AspNetCore.Identity.AzureTable
                 await Task.WhenAll(tasks).ConfigureAwait(false);
             }
 
-            return bag.ToList();
+            return [.. bag];
         }
 
         /// <summary>
@@ -250,7 +240,7 @@ namespace ElCamino.AspNetCore.Identity.AzureTable
                 }, cancellationToken).ConfigureAwait(false)).ToList();
             }
 
-            return new List<TUser>();
+            return [];
         }
 
         /// <inheritdoc/>
@@ -258,7 +248,7 @@ namespace ElCamino.AspNetCore.Identity.AzureTable
         {
             cancellationToken.ThrowIfCancellationRequested();
             ThrowIfDisposed();
-            if (user is null) throw new ArgumentNullException(nameof(user));
+            ArgumentNullException.ThrowIfNull(user);
             if (string.IsNullOrWhiteSpace(roleName))
             {
                 throw new ArgumentException(IdentityResources.ValueCannotBeNullOrEmpty, nameof(roleName));
@@ -286,7 +276,7 @@ namespace ElCamino.AspNetCore.Identity.AzureTable
         /// <inheritdoc/>
         public Task<bool> RoleExistsAsync(string roleName, CancellationToken cancellationToken = default)
         {
-            return _roleTable.QueryAsync<TableEntity>(filter: BuildRoleQuery(roleName), maxPerPage: 1, select: new List<string>() { nameof(Model.IdentityRole.Name) }, cancellationToken: cancellationToken).AnyAsync(cancellationToken);
+            return _roleTable.QueryAsync<TableEntity>(filter: BuildRoleQuery(roleName), maxPerPage: 1, select: [nameof(Model.IdentityRole.Name)], cancellationToken: cancellationToken).AnyAsync(cancellationToken);
         }
 
         /// <inheritdoc/>
@@ -294,7 +284,7 @@ namespace ElCamino.AspNetCore.Identity.AzureTable
         {
             cancellationToken.ThrowIfCancellationRequested();
             ThrowIfDisposed();
-            if (user is null) throw new ArgumentNullException(nameof(user));
+            ArgumentNullException.ThrowIfNull(user);
             if (string.IsNullOrWhiteSpace(roleName))
                 throw new ArgumentException(IdentityResources.ValueCannotBeNullOrEmpty, nameof(roleName));
 
@@ -337,7 +327,7 @@ namespace ElCamino.AspNetCore.Identity.AzureTable
             const double pageSize = 50.0;
             int pages = (int)Math.Ceiling(((double)userIds.Count() / pageSize));
             List<string> listTqs = new List<string>(pages);
-            IEnumerable<string> tempUserIds = Enumerable.Empty<string>();
+            IEnumerable<string> tempUserIds = [];
 
             for (int currentPage = 1; currentPage <= pages; currentPage++)
             {
@@ -378,7 +368,7 @@ namespace ElCamino.AspNetCore.Identity.AzureTable
 
             }
 
-            ConcurrentBag<TUser> bag = new ConcurrentBag<TUser>();
+            ConcurrentBag<TUser> bag = [];
 #if DEBUG
             DateTime startUserAggTotal = DateTime.UtcNow;
 #endif
@@ -440,10 +430,10 @@ namespace ElCamino.AspNetCore.Identity.AzureTable
         {
 
             TUser? user = default;
-            IEnumerable<TUserRole> roles = Enumerable.Empty<TUserRole>();
-            IEnumerable<TUserClaim> claims = Enumerable.Empty<TUserClaim>();
-            IEnumerable<TUserLogin> logins = Enumerable.Empty<TUserLogin>();
-            IEnumerable<TUserToken> tokens = Enumerable.Empty<TUserToken>();
+            IEnumerable<TUserRole> roles = [];
+            IEnumerable<TUserClaim> claims = [];
+            IEnumerable<TUserLogin> logins = [];
+            IEnumerable<TUserToken> tokens = [];
 
             var vUser = userResults.Where(u => u.RowKey.Equals(userId) && u.PartitionKey.Equals(userId)).SingleOrDefault();
 
@@ -490,7 +480,7 @@ namespace ElCamino.AspNetCore.Identity.AzureTable
         {
             cancellationToken.ThrowIfCancellationRequested();
             ThrowIfDisposed();
-            if (user is null) throw new ArgumentNullException(nameof(user));
+            ArgumentNullException.ThrowIfNull(user);
 
             List<Task> tasks = new List<Task>(50);
             string userPartitionKey = _keyHelper.GenerateRowKeyUserId(ConvertIdToString(user.Id));
@@ -530,7 +520,7 @@ namespace ElCamino.AspNetCore.Identity.AzureTable
 
             try
             {
-                await Task.WhenAll(tasks.ToArray()).ConfigureAwait(false);
+                await Task.WhenAll([.. tasks]).ConfigureAwait(false);
                 return IdentityResult.Success;
             }
             catch (AggregateException aggex)

--- a/src/ElCamino.AspNetCore.Identity.AzureTable/UserStore.cs
+++ b/src/ElCamino.AspNetCore.Identity.AzureTable/UserStore.cs
@@ -291,7 +291,7 @@ namespace ElCamino.AspNetCore.Identity.AzureTable
             string userPartitionKey = _keyHelper.GenerateRowKeyUserId(ConvertIdToString(user.Id)).ToString();
             try
             {
-                var item = await _userTable.GetEntityOrDefaultAsync<TUserRole>(userPartitionKey, _keyHelper.GenerateRowKeyIdentityRole(roleName), cancellationToken: cancellationToken).ConfigureAwait(false);
+                var item = await _userTable.GetEntityOrDefaultAsync<TUserRole>(userPartitionKey, _keyHelper.GenerateRowKeyIdentityRole(roleName).ToString(), cancellationToken: cancellationToken).ConfigureAwait(false);
 
                 if (item is not null)
                 {

--- a/src/ElCamino.AspNetCore.Identity.AzureTable/UserStore.cs
+++ b/src/ElCamino.AspNetCore.Identity.AzureTable/UserStore.cs
@@ -95,7 +95,7 @@ namespace ElCamino.AspNetCore.Identity.AzureTable
 
 
             TUserRole userToRole = new TUserRole();
-            userToRole.PartitionKey = _keyHelper.GenerateRowKeyUserId(ConvertIdToString(user.Id));
+            userToRole.PartitionKey = _keyHelper.GenerateRowKeyUserId(ConvertIdToString(user.Id)).ToString();
             userToRole.RoleId = roleT.Id;
             userToRole.RoleName = roleT.Name;
             userToRole.UserId = user.Id;
@@ -126,7 +126,7 @@ namespace ElCamino.AspNetCore.Identity.AzureTable
             }
 
             const string roleName = nameof(Model.IdentityUserRole<string>.RoleName);
-            string userId = _keyHelper.GenerateRowKeyUserId(ConvertIdToString(user.Id));
+            var userId = _keyHelper.GenerateRowKeyUserId(ConvertIdToString(user.Id));
             // Changing to a live query to mimic EF UserStore in Identity 3.0
 
             var filterString = TableQuery.CombineFilters(
@@ -254,7 +254,7 @@ namespace ElCamino.AspNetCore.Identity.AzureTable
                 throw new ArgumentException(IdentityResources.ValueCannotBeNullOrEmpty, nameof(roleName));
             }
 
-            string userId = _keyHelper.GenerateRowKeyUserId(ConvertIdToString(user.Id));
+            var userId = _keyHelper.GenerateRowKeyUserId(ConvertIdToString(user.Id));
             // Changing to a live query to mimic EF UserStore in Identity 3.0
 
             var filterString = TableQuery.CombineFilters(
@@ -288,7 +288,7 @@ namespace ElCamino.AspNetCore.Identity.AzureTable
             if (string.IsNullOrWhiteSpace(roleName))
                 throw new ArgumentException(IdentityResources.ValueCannotBeNullOrEmpty, nameof(roleName));
 
-            string userPartitionKey = _keyHelper.GenerateRowKeyUserId(ConvertIdToString(user.Id));
+            string userPartitionKey = _keyHelper.GenerateRowKeyUserId(ConvertIdToString(user.Id)).ToString();
             try
             {
                 var item = await _userTable.GetEntityOrDefaultAsync<TUserRole>(userPartitionKey, _keyHelper.GenerateRowKeyIdentityRole(roleName), cancellationToken: cancellationToken).ConfigureAwait(false);
@@ -483,9 +483,9 @@ namespace ElCamino.AspNetCore.Identity.AzureTable
             ArgumentNullException.ThrowIfNull(user);
 
             List<Task> tasks = new List<Task>(50);
-            string userPartitionKey = _keyHelper.GenerateRowKeyUserId(ConvertIdToString(user.Id));
-            var userRows = await GetUserAggregateQueryAsync(userPartitionKey, cancellationToken).ToListAsync(cancellationToken).ConfigureAwait(false);
-            tasks.Add(DeleteAllUserRows(userPartitionKey, userRows));
+            string userPartitionKey = _keyHelper.GenerateRowKeyUserId(ConvertIdToString(user.Id)).ToString();
+            var userRows = await GetUserAggregateQueryAsync(userPartitionKey.ToString(), cancellationToken).ToListAsync(cancellationToken).ConfigureAwait(false);
+            tasks.Add(DeleteAllUserRowsAsync(userPartitionKey, userRows));
 
             var deleteUserNameIndex = CreateUserNameIndex(userPartitionKey, user.UserName);
             tasks.Add(_indexTable.DeleteEntityAsync(deleteUserNameIndex.PartitionKey, deleteUserNameIndex.RowKey, TableConstants.ETagWildcard, cancellationToken: cancellationToken));

--- a/src/ElCamino.AspNetCore.Identity.AzureTable/UserStore.cs
+++ b/src/ElCamino.AspNetCore.Identity.AzureTable/UserStore.cs
@@ -234,7 +234,7 @@ namespace ElCamino.AspNetCore.Identity.AzureTable
                 {
                     return GetUserAggregateQueryAsync(userId, setFilterByUserId: getTableQueryFilterByUserId, whereClaim: null, whereRole: (ur) =>
                     {
-                        return ur.RowKey == _keyHelper.GenerateRowKeyIdentityUserRole(roleName);
+                        return ur.RowKey.AsSpan().Equals(_keyHelper.GenerateRowKeyIdentityUserRole(roleName), StringComparison.OrdinalIgnoreCase);
                     }, cancellationToken: cancellationToken);
 
                 }, cancellationToken).ConfigureAwait(false)).ToList();

--- a/src/ElCamino.Azure.Data.Tables/ElCamino.Azure.Data.Tables.csproj
+++ b/src/ElCamino.Azure.Data.Tables/ElCamino.Azure.Data.Tables.csproj
@@ -5,8 +5,8 @@
     <Copyright>Copyright ©  David Melendez, MIT License</Copyright>
     <AssemblyTitle>Azure Table Storage Extensions</AssemblyTitle>
     <Authors>David Melendez</Authors>
-    <TargetFrameworks>netstandard2.0;net6.0;net8.0</TargetFrameworks>
-    <LangVersion>12.0</LangVersion>
+    <TargetFrameworks>netstandard2.0;net8.0;net9.0</TargetFrameworks>
+    <LangVersion>13.0</LangVersion>
     <AssemblyName>ElCamino.Azure.Data.Tables</AssemblyName>
     <AssemblyOriginatorKeyFile>../../tools/key.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
@@ -20,7 +20,7 @@
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/dlmelendez/identityazuretable.git</RepositoryUrl>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
-    <Version>8.0</Version>
+    <Version>9.0</Version>
     <PackageProjectUrl>https://dlmelendez.github.io/identityazuretable</PackageProjectUrl>
     <!--<DebugType>Full</DebugType>-->
     <!-- DebugType Full is needed for test code coverage, but .nuget symbols doesn't like it-->

--- a/src/ElCamino.Azure.Data.Tables/ElCamino.Azure.Data.Tables.csproj
+++ b/src/ElCamino.Azure.Data.Tables/ElCamino.Azure.Data.Tables.csproj
@@ -5,7 +5,7 @@
     <Copyright>Copyright ©  David Melendez, MIT License</Copyright>
     <AssemblyTitle>Azure Table Storage Extensions</AssemblyTitle>
     <Authors>David Melendez</Authors>
-    <TargetFrameworks>netstandard2.0;net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
     <LangVersion>13.0</LangVersion>
     <AssemblyName>ElCamino.Azure.Data.Tables</AssemblyName>
     <AssemblyOriginatorKeyFile>../../tools/key.snk</AssemblyOriginatorKeyFile>

--- a/src/ElCamino.Azure.Data.Tables/QueryComparison.cs
+++ b/src/ElCamino.Azure.Data.Tables/QueryComparison.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace ElCamino.Azure.Data.Tables
+{
+    /// <summary>
+    /// EXPERIMENTAL: Used for TableQueryBuilder
+    /// From https://github.com/Azure/azure-storage-net/blob/v9.3.2/Lib/Common/Table/QueryComparisons.cs
+    /// </summary>
+    public enum QueryComparison : byte
+    {
+        /// <summary>
+        /// Represents the Equal operator.
+        /// </summary>
+        Equal,
+
+        /// <summary>
+        /// Represents the Not Equal operator.
+        /// </summary>
+        NotEqual,
+
+        /// <summary>
+        /// Represents the Greater Than operator.
+        /// </summary>
+        GreaterThan,
+
+        /// <summary>
+        /// Represents the Greater Than or Equal operator.
+        /// </summary>
+        GreaterThanOrEqual,
+
+        /// <summary>
+        /// Represents the Less Than operator.
+        /// </summary>
+        LessThan,
+
+        /// <summary>
+        /// Represents the Less Than or Equal operator.
+        /// </summary>
+        LessThanOrEqual
+    }
+}

--- a/src/ElCamino.Azure.Data.Tables/QueryComparisons.cs
+++ b/src/ElCamino.Azure.Data.Tables/QueryComparisons.cs
@@ -16,6 +16,8 @@
 // -----------------------------------------------------------------------------------------
 
 
+using ElCamino.Azure.Data.Tables;
+
 namespace Azure.Data.Tables
 {
     /// <summary>
@@ -52,5 +54,25 @@ namespace Azure.Data.Tables
         /// Represents the Less Than or Equal operator.
         /// </summary>
         public const string LessThanOrEqual = "le";
+
+        /// <summary>
+        /// Gets the OData string representation of the specified comparison operator.
+        /// </summary>
+        /// <param name="comparison"></param>
+        /// <returns></returns>
+        /// <exception cref="ArgumentException"></exception>
+        public static string GetComparison(QueryComparison comparison)
+        {
+            return comparison switch
+            {
+                QueryComparison.Equal => QueryComparisons.Equal,
+                QueryComparison.NotEqual => QueryComparisons.NotEqual,
+                QueryComparison.GreaterThan => QueryComparisons.GreaterThan,
+                QueryComparison.GreaterThanOrEqual => QueryComparisons.GreaterThanOrEqual,
+                QueryComparison.LessThan => QueryComparisons.LessThan,
+                QueryComparison.LessThanOrEqual => QueryComparisons.LessThanOrEqual,
+                _ => throw new ArgumentException($"Invalid comparison: {comparison}", nameof(comparison)),
+            };
+        }
     }
 }

--- a/src/ElCamino.Azure.Data.Tables/QueryCondition.cs
+++ b/src/ElCamino.Azure.Data.Tables/QueryCondition.cs
@@ -1,0 +1,45 @@
+﻿#if NET9_0_OR_GREATER
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace ElCamino.Azure.Data.Tables
+{
+    /// <summary>
+    /// EXPERIMENTAL: Used for TableQueryBuilder
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    public ref struct QueryCondition<T>
+        where T : allows ref struct
+    {
+        /// <summary>
+        /// Query condition for adding filter conditon to the TableQueryBuilder
+        /// </summary>
+        /// <param name="propertyName"></param>
+        /// <param name="operation"></param>
+        /// <param name="givenValue"></param>
+        public QueryCondition(ReadOnlySpan<char> propertyName, QueryComparison operation, T givenValue)
+        {
+            PropertyName = propertyName;
+            Operation = operation;
+            GivenValue = givenValue;
+        }
+
+        /// <summary>
+        /// Property name to query
+        /// </summary>
+        public ReadOnlySpan<char> PropertyName { get; }
+
+        /// <summary>
+        /// Query operation <see cref="QueryComparison"/> 
+        /// </summary>
+        public QueryComparison Operation { get; }
+
+        /// <summary>
+        /// Value to compare
+        /// </summary>
+        public T GivenValue { get; }
+    }
+}
+#endif

--- a/src/ElCamino.Azure.Data.Tables/TableClientExtensions.cs
+++ b/src/ElCamino.Azure.Data.Tables/TableClientExtensions.cs
@@ -93,7 +93,7 @@ namespace Azure.Data.Tables
             partitionKey = partitionKey ?? throw new ArgumentNullException(nameof(partitionKey));
             rowKey = rowKey ?? throw new ArgumentNullException(nameof(rowKey));
 
-            string filterString = TableQuery.CombineFilters(
+            var filterString = TableQuery.CombineFilters(
                 TableQuery.GenerateFilterCondition(nameof(TableEntity.PartitionKey), QueryComparisons.Equal, partitionKey),
                 TableOperators.And,
                 TableQuery.GenerateFilterCondition(nameof(TableEntity.RowKey), QueryComparisons.Equal, rowKey));

--- a/src/ElCamino.Azure.Data.Tables/TableClientExtensions.cs
+++ b/src/ElCamino.Azure.Data.Tables/TableClientExtensions.cs
@@ -3,7 +3,9 @@
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
 
+#pragma warning disable IDE0130 // Namespace does not match folder structure
 namespace Azure.Data.Tables
+#pragma warning restore IDE0130 // Namespace does not match folder structure
 {
     /// <summary>
     /// Extensions for the <seealso cref="TableClient"/>

--- a/src/ElCamino.Azure.Data.Tables/TableClientExtensions.cs
+++ b/src/ElCamino.Azure.Data.Tables/TableClientExtensions.cs
@@ -96,7 +96,7 @@ namespace Azure.Data.Tables
             var filterString = TableQuery.CombineFilters(
                 TableQuery.GenerateFilterCondition(nameof(TableEntity.PartitionKey), QueryComparisons.Equal, partitionKey),
                 TableOperators.And,
-                TableQuery.GenerateFilterCondition(nameof(TableEntity.RowKey), QueryComparisons.Equal, rowKey));
+                TableQuery.GenerateFilterCondition(nameof(TableEntity.RowKey), QueryComparisons.Equal, rowKey)).ToString();
 
             var page = await table.QueryAsync<T>(filter: filterString, maxPerPage: 1, select: select, cancellationToken)
                         .AsPages(continuationToken: null, pageSizeHint: 1).FirstOrDefaultAsync(cancellationToken).ConfigureAwait(false);

--- a/src/ElCamino.Azure.Data.Tables/TableOperator.cs
+++ b/src/ElCamino.Azure.Data.Tables/TableOperator.cs
@@ -15,46 +15,28 @@
 // </copyright>
 // -----------------------------------------------------------------------------------------
 
-using ElCamino.Azure.Data.Tables;
-
-namespace Azure.Data.Tables
+namespace ElCamino.Azure.Data.Tables
 {
     /// <summary>
+    /// EXPERIMENTAL: Used for TableQueryBuilder
     /// From https://github.com/Azure/azure-storage-net/blob/v9.3.2/Lib/Common/Table/TableOperators.cs
     /// </summary>
-    public static class TableOperators
+    public enum TableOperator : byte
     {
         /// <summary>
         /// Represents the And operator.
         /// </summary>
 
-        public const string And = "and";
+        And,
 
         /// <summary>
         /// Represents the Not operator.
         /// </summary>
-        public const string Not = "not";
+        Not,
 
         /// <summary>
         /// Represents the Or operator.
         /// </summary>
-        public const string Or = "or";
-
-        /// <summary>
-        /// Gets the operator string for the specified <see cref="TableOperator"/>.
-        /// </summary>
-        /// <param name="tableOperator"></param>
-        /// <returns></returns>
-        /// <exception cref="System.ArgumentException"></exception>
-        public static string GetOperator(TableOperator tableOperator)
-        {
-            return tableOperator switch
-            {
-                TableOperator.And => And,
-                TableOperator.Not => Not,
-                TableOperator.Or => Or,
-                _ => throw new ArgumentException($"Invalid table operator: {tableOperator}", nameof(tableOperator)),
-            };
-        }
+        Or
     }
 }

--- a/src/ElCamino.Azure.Data.Tables/TableQuery.cs
+++ b/src/ElCamino.Azure.Data.Tables/TableQuery.cs
@@ -50,9 +50,8 @@ namespace Azure.Data.Tables
         /// <param name="operation">A string containing the comparison operator to use.</param>
         /// <param name="givenValue">A string containing the value to compare with the property.</param>
         /// <returns>A string containing the formatted filter condition.</returns>
-        public static string GenerateFilterCondition(string propertyName, string operation, string? givenValue)
+        public static ReadOnlySpan<char> GenerateFilterCondition(ReadOnlySpan<char> propertyName, ReadOnlySpan<char> operation, ReadOnlySpan<char> givenValue)
         {
-            givenValue ??= string.Empty;
             return GenerateFilterCondition(propertyName, operation, givenValue, EdmType.String);
         }
 
@@ -63,7 +62,7 @@ namespace Azure.Data.Tables
         /// <param name="operation">A string containing the comparison operator to use.</param>
         /// <param name="givenValue">A <c>bool</c> containing the value to compare with the property.</param>
         /// <returns>A string containing the formatted filter condition.</returns>
-        public static string GenerateFilterConditionForBool(string propertyName, string operation, bool givenValue)
+        public static ReadOnlySpan<char> GenerateFilterConditionForBool(ReadOnlySpan<char> propertyName, ReadOnlySpan<char> operation, bool givenValue)
         {
             return GenerateFilterCondition(propertyName, operation, givenValue ? OdataTrue : OdataFalse, EdmType.Boolean);
         }
@@ -75,9 +74,9 @@ namespace Azure.Data.Tables
         /// <param name="operation">A string containing the comparison operator to use.  <seealso cref="QueryComparisons.Equal"/> Is Null or <seealso cref="QueryComparisons.NotEqual"/> Not Null</param>
         /// <returns>A string containing the formatted filter condition.</returns>
         /// <exception cref="ArgumentOutOfRangeException"></exception>
-        public static string GenerateFilterConditionForBoolNull(string propertyName, string operation)
+        public static ReadOnlySpan<char> GenerateFilterConditionForBoolNull(ReadOnlySpan<char> propertyName, ReadOnlySpan<char> operation)
         {
-            string validBoolean = $"({GenerateFilterConditionForBool(propertyName, QueryComparisons.Equal, true)} {TableOperators.Or} {GenerateFilterConditionForBool(propertyName, QueryComparisons.Equal, false)})";
+            ReadOnlySpan<char> validBoolean = $"({GenerateFilterConditionForBool(propertyName, QueryComparisons.Equal, true)} {TableOperators.Or} {GenerateFilterConditionForBool(propertyName, QueryComparisons.Equal, false)})";
             switch (operation)
             {
                 case QueryComparisons.Equal: //isNull
@@ -88,7 +87,7 @@ namespace Azure.Data.Tables
                     break;
             }
 
-            throw new ArgumentOutOfRangeException(nameof(operation), $"{operation ?? string.Empty} is not supported. Only {QueryComparisons.Equal} and {QueryComparisons.NotEqual} operators are supported.");
+            throw new ArgumentOutOfRangeException(nameof(operation), $"{operation} is not supported. Only {QueryComparisons.Equal} and {QueryComparisons.NotEqual} operators are supported.");
         }
 
         /// <summary>
@@ -98,27 +97,12 @@ namespace Azure.Data.Tables
         /// <param name="operation">A string containing the comparison operator to use.</param>
         /// <param name="givenValue">A byte array containing the value to compare with the property.</param>
         /// <returns>A string containing the formatted filter condition.</returns>
-        public static string GenerateFilterConditionForBinary(
-            string propertyName,
-            string operation,
+        public static ReadOnlySpan<char> GenerateFilterConditionForBinary(
+            ReadOnlySpan<char> propertyName,
+            ReadOnlySpan<char> operation,
             byte[] givenValue)
         {
-            string hash;
-
-#if NET6_0_OR_GREATER
-            hash = Convert.ToHexString(givenValue).ToLowerInvariant();
-#else
-            StringBuilder sb = new StringBuilder();
-
-            foreach (byte b in givenValue)
-            {
-                sb.AppendFormat("{0:x2}", b);
-            }
-
-            hash = sb.ToString();
-#endif
-
-            return GenerateFilterCondition(propertyName, operation, hash, EdmType.Binary);
+            return GenerateFilterCondition(propertyName, operation, Convert.ToHexString(givenValue).ToLowerInvariant(), EdmType.Binary);
         }
 
         /// <summary>
@@ -128,7 +112,7 @@ namespace Azure.Data.Tables
         /// <param name="operation">A string containing the comparison operator to use.</param>
         /// <param name="givenValue">A <see cref="DateTimeOffset"/> containing the value to compare with the property.</param>
         /// <returns>A string containing the formatted filter condition.</returns>
-        public static string GenerateFilterConditionForDate(string propertyName, string operation, DateTimeOffset givenValue)
+        public static ReadOnlySpan<char> GenerateFilterConditionForDate(ReadOnlySpan<char> propertyName, ReadOnlySpan<char> operation, DateTimeOffset givenValue)
         {
             return GenerateFilterCondition(propertyName, operation, givenValue.UtcDateTime.ToString("o", CultureInfo.InvariantCulture), EdmType.DateTime);
         }
@@ -140,7 +124,7 @@ namespace Azure.Data.Tables
         /// <param name="operation">A string containing the comparison operator to use.</param>
         /// <param name="givenValue">A <see cref="double"/> containing the value to compare with the property.</param>
         /// <returns>A string containing the formatted filter condition.</returns>
-        public static string GenerateFilterConditionForDouble(string propertyName, string operation, double givenValue)
+        public static ReadOnlySpan<char> GenerateFilterConditionForDouble(ReadOnlySpan<char> propertyName, ReadOnlySpan<char> operation, double givenValue)
         {
             return GenerateFilterCondition(propertyName, operation, Convert.ToString(givenValue, CultureInfo.InvariantCulture), EdmType.Double);
         }
@@ -152,7 +136,7 @@ namespace Azure.Data.Tables
         /// <param name="operation">A string containing the comparison operator to use.</param>
         /// <param name="givenValue">An <see cref="int"/> containing the value to compare with the property.</param>
         /// <returns>A string containing the formatted filter condition.</returns>
-        public static string GenerateFilterConditionForInt(string propertyName, string operation, int givenValue)
+        public static ReadOnlySpan<char> GenerateFilterConditionForInt(ReadOnlySpan<char> propertyName, ReadOnlySpan<char> operation, int givenValue)
         {
             return GenerateFilterCondition(propertyName, operation, Convert.ToString(givenValue, CultureInfo.InvariantCulture), EdmType.Int32);
         }
@@ -164,7 +148,7 @@ namespace Azure.Data.Tables
         /// <param name="operation">A string containing the comparison operator to use.</param>
         /// <param name="givenValue">An <see cref="long"/> containing the value to compare with the property.</param>
         /// <returns>A string containing the formatted filter condition.</returns>
-        public static string GenerateFilterConditionForLong(string propertyName, string operation, long givenValue)
+        public static ReadOnlySpan<char> GenerateFilterConditionForLong(ReadOnlySpan<char> propertyName, ReadOnlySpan<char> operation, long givenValue)
         {
             return GenerateFilterCondition(propertyName, operation, Convert.ToString(givenValue, CultureInfo.InvariantCulture), EdmType.Int64);
         }
@@ -176,7 +160,7 @@ namespace Azure.Data.Tables
         /// <param name="operation">A string containing the comparison operator to use.</param>
         /// <param name="givenValue">A <see cref="Guid"/> containing the value to compare with the property.</param>
         /// <returns>A string containing the formatted filter condition.</returns>
-        public static string GenerateFilterConditionForGuid(string propertyName, string operation, Guid givenValue)
+        public static ReadOnlySpan<char> GenerateFilterConditionForGuid(ReadOnlySpan<char> propertyName, ReadOnlySpan<char> operation, Guid givenValue)
         {
             return GenerateFilterCondition(propertyName, operation, givenValue.ToString(), EdmType.Guid);
         }
@@ -188,9 +172,9 @@ namespace Azure.Data.Tables
         /// <param name="operation">A string containing the comparison operator to use. <seealso cref="QueryComparisons.Equal"/> Is Null or <seealso cref="QueryComparisons.NotEqual"/> Not Null</param>
         /// <returns>A string containing the formatted filter condition.</returns>
         /// <exception cref="ArgumentOutOfRangeException"></exception>
-        public static string GenerateFilterConditionForStringNull(string propertyName, string operation)
+        public static ReadOnlySpan<char> GenerateFilterConditionForStringNull(ReadOnlySpan<char> propertyName, ReadOnlySpan<char> operation)
         {
-            string validString = $"{propertyName} {QueryComparisons.GreaterThan} ''";
+            ReadOnlySpan<char> validString = $"{propertyName} {QueryComparisons.GreaterThan} ''";
             switch (operation)
             {
                 case QueryComparisons.Equal: //isNull
@@ -201,49 +185,42 @@ namespace Azure.Data.Tables
                     break;
             }
 
-            throw new ArgumentOutOfRangeException(nameof(operation), $"{operation ?? string.Empty} is not supported. Only {QueryComparisons.Equal} and {QueryComparisons.NotEqual} operators are supported.");
+            throw new ArgumentOutOfRangeException(nameof(operation), $"{operation} is not supported. Only {QueryComparisons.Equal} and {QueryComparisons.NotEqual} operators are supported.");
         }
 
-#if NET8_0_OR_GREATER
         /// <summary>
         /// Generate operand value for the given value and <see cref="EdmType"/>.
         /// </summary>
         /// <param name="givenValue"></param>
         /// <param name="edmType"></param>
         /// <returns></returns>
-        private static ReadOnlySpan<char> GenerateValueOperand(string givenValue, EdmType edmType)
+        private static ReadOnlySpan<char> GenerateValueOperand(ReadOnlySpan<char> givenValue, EdmType edmType)
         {
-            switch(edmType)
+            switch (edmType)
             {
                 case EdmType.Boolean:
                 case EdmType.Int32:
-                    return givenValue.AsSpan();
+                    return givenValue;
                 case EdmType.Double:
                     bool isInteger = int.TryParse(givenValue, out _);
                     if (isInteger)
                     {
-                        return $"{givenValue}.0".AsSpan();
+                        return $"{givenValue}.0";
                     }
-                    return givenValue.AsSpan();
+                    return givenValue;
                 case EdmType.Int64:
-                    return $"{givenValue}L".AsSpan();
+                    return $"{givenValue}L";
                 case EdmType.DateTime:
-                    return $"datetime'{givenValue}'".AsSpan();
+                    return $"datetime'{givenValue}'";
                 case EdmType.Guid:
-                    return $"guid'{givenValue}'".AsSpan();
+                    return $"guid'{givenValue}'";
                 case EdmType.Binary:
-                    return $"X'{givenValue}'".AsSpan();
+                    return $"X'{givenValue}'";
             }
             // OData readers expect single quote to be escaped in a param value.
-            return string.Format(CultureInfo.InvariantCulture, "'{0}'", givenValue.Replace("'", "''")).AsSpan();
+            return string.Format(CultureInfo.InvariantCulture, "'{0}'", givenValue.ToString().Replace("'", "''"));
         }
 
-        private static ReadOnlySpan<char> GenerateFilterCondition(ReadOnlySpan<char> propertyName, ReadOnlySpan<char> operation, string givenValue, EdmType edmType)
-        {
-            ReadOnlySpan<char> valueOperand = GenerateValueOperand(givenValue, edmType);
-            return $"{propertyName} {operation} {valueOperand}".AsSpan();
-        }
-#endif
         /// <summary>
         /// Generates a property filter condition string for the <see cref="EdmType"/> value, formatted as the specified <see cref="EdmType"/>.
         /// </summary>
@@ -252,57 +229,10 @@ namespace Azure.Data.Tables
         /// <param name="givenValue">A string containing the value to compare with the property.</param>
         /// <param name="edmType">The <see cref="EdmType"/> to format the value as.</param>
         /// <returns>A string containing the formatted filter condition.</returns>
-        private static string GenerateFilterCondition(string propertyName, string operation, string givenValue, EdmType edmType)
+        private static ReadOnlySpan<char> GenerateFilterCondition(ReadOnlySpan<char> propertyName, ReadOnlySpan<char> operation, ReadOnlySpan<char> givenValue, EdmType edmType)
         {
-#if NET9_0_OR_GREATER
-            return GenerateFilterCondition(propertyName.AsSpan(), operation.AsSpan(), givenValue, edmType).ToString();
-#else
-            string valueOperand;
-            if (edmType == EdmType.Boolean || edmType == EdmType.Int32)
-            {
-                valueOperand = givenValue;
-            }
-            else if (edmType == EdmType.Double)
-            {
-                bool isInteger = int.TryParse(givenValue, out _);
-                valueOperand = isInteger ? string.Format(CultureInfo.InvariantCulture, "{0}.0", givenValue) : givenValue;
-            }
-            else if (edmType == EdmType.Int64)
-            {
-                valueOperand = string.Format(CultureInfo.InvariantCulture, "{0}L", givenValue);
-            }
-            else if (edmType == EdmType.DateTime)
-            {
-                valueOperand = string.Format(CultureInfo.InvariantCulture, "datetime'{0}'", givenValue);
-            }
-            else if (edmType == EdmType.Guid)
-            {
-                valueOperand = string.Format(CultureInfo.InvariantCulture, "guid'{0}'", givenValue);
-            }
-            else if (edmType == EdmType.Binary)
-            {
-                valueOperand = string.Format(CultureInfo.InvariantCulture, "X'{0}'", givenValue);
-            }
-            else
-            {
-                // OData readers expect single quote to be escaped in a param value.
-                valueOperand = string.Format(CultureInfo.InvariantCulture, "'{0}'", givenValue.Replace("'", "''"));
-            }
-
-            return string.Format(CultureInfo.InvariantCulture, "{0} {1} {2}", propertyName, operation, valueOperand);
-#endif
-        }
-
-        /// <summary>
-        /// Creates a filter condition using the specified logical operator on two filter conditions.
-        /// </summary>
-        /// <param name="filterA">A string containing the first formatted filter condition.</param>
-        /// <param name="operatorString">A string containing the operator to use (AND, OR).</param>
-        /// <param name="filterB">A string containing the second formatted filter condition.</param>
-        /// <returns>A string containing the combined filter expression.</returns>
-        public static string CombineFilters(string filterA, string operatorString, string filterB)
-        {
-            return string.Format(CultureInfo.InvariantCulture, "({0}) {1} ({2})", filterA, operatorString, filterB);
+            ReadOnlySpan<char> valueOperand = GenerateValueOperand(givenValue, edmType);
+            return $"{propertyName} {operation} {valueOperand}";
         }
 
         /// <summary>
@@ -312,10 +242,9 @@ namespace Azure.Data.Tables
         /// <param name="operatorString">A string containing the operator to use (AND, OR).</param>
         /// <param name="filterB">A ReadOnlySpan containing the second formatted filter condition.</param>
         /// <returns>A ReadOnlySpan containing the combined filter expression.</returns>
-        public static ReadOnlySpan<char> CombineFilters(ReadOnlySpan<char> filterA, string operatorString, ReadOnlySpan<char> filterB)
+        public static ReadOnlySpan<char> CombineFilters(ReadOnlySpan<char> filterA, ReadOnlySpan<char> operatorString, ReadOnlySpan<char> filterB)
         {
-            return $"({filterA.ToString()}) {operatorString} ({filterB.ToString()})".AsSpan();
+            return $"({filterA}) {operatorString} ({filterB})";
         }
-
     }
 }

--- a/src/ElCamino.Azure.Data.Tables/TableQuery.cs
+++ b/src/ElCamino.Azure.Data.Tables/TableQuery.cs
@@ -18,7 +18,9 @@
 using System.Globalization;
 using System.Text;
 
+#pragma warning disable IDE0130 // Namespace does not match folder structure
 namespace Azure.Data.Tables
+#pragma warning restore IDE0130 // Namespace does not match folder structure
 {
     /// <summary>
     /// From https://github.com/Azure/azure-storage-net/blob/v9.3.2/Lib/Common/Table/TableQuery.cs

--- a/src/ElCamino.Azure.Data.Tables/TableQueryBuilder.cs
+++ b/src/ElCamino.Azure.Data.Tables/TableQueryBuilder.cs
@@ -1,0 +1,171 @@
+﻿#if NET9_0_OR_GREATER
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Azure.Data.Tables;
+
+namespace ElCamino.Azure.Data.Tables
+{
+    /// <summary>
+    /// EXPERIMENTAL: API is subject to change
+    /// This class allows for a fluent query builder for Azure Table Storage using OData.
+    /// </summary>
+    public class TableQueryBuilder
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TableQueryBuilder"/> class for fluent query building for Azure Table Storage using OData.
+        /// </summary>
+        public TableQueryBuilder() { }
+
+        private StringBuilder _queryBuilder = new StringBuilder();
+        private uint _filterCount = 0;
+        private uint _beginGroupCount = 0;
+        private uint _endGroupCount = 0;
+
+        /// <summary>
+        /// Gets a value indicating whether the query has any filters.
+        /// </summary>
+        public bool HasFilter => _filterCount > 0;
+
+        private void AppendCondition(ReadOnlySpan<char> condition)
+        {
+            AppendBeginGroup();
+            _queryBuilder.Append(condition);
+            _filterCount++;
+            AppendEndGroup();
+        }
+
+        /// <summary>
+        /// Adds a filter condition to the query.
+        /// </summary>
+        /// <param name="queryCondition"></param>
+        /// <returns></returns>
+        public TableQueryBuilder AddFilter(QueryCondition<ReadOnlySpan<char>> queryCondition)
+        {
+            AppendCondition(TableQuery.GenerateFilterCondition(
+                queryCondition.PropertyName, QueryComparisons.GetComparison(queryCondition.Operation), queryCondition.GivenValue));
+            return this;
+        }
+
+        /// <summary>
+        /// Adds a filter condition to the query.
+        /// </summary>
+        /// <param name="queryCondition"></param>
+        /// <returns></returns>
+        public TableQueryBuilder AddFilter(QueryCondition<string?> queryCondition)
+        {
+            AppendCondition(
+                queryCondition.GivenValue is null ? 
+                TableQuery.GenerateFilterConditionForStringNull(
+                    queryCondition.PropertyName, QueryComparisons.GetComparison(queryCondition.Operation)) 
+                :
+                TableQuery.GenerateFilterCondition(
+                queryCondition.PropertyName, QueryComparisons.GetComparison(queryCondition.Operation), queryCondition.GivenValue));
+            return this;
+        }
+
+        /// <summary>
+        /// Adds a filter condition to the query.
+        /// </summary>
+        /// <param name="queryCondition"></param>
+        /// <returns></returns>
+        public TableQueryBuilder AddFilter(QueryCondition<bool?> queryCondition)
+        {
+            AppendCondition(
+                !queryCondition.GivenValue.HasValue ?
+                TableQuery.GenerateFilterConditionForBoolNull(
+                    queryCondition.PropertyName, QueryComparisons.GetComparison(queryCondition.Operation))
+                :
+                TableQuery.GenerateFilterConditionForBool(
+                queryCondition.PropertyName, QueryComparisons.GetComparison(queryCondition.Operation), queryCondition.GivenValue.Value));
+            return this;
+        }
+
+        /// <summary>
+        /// Combines filters using the specified table operator.
+        /// </summary>
+        /// <param name="tableOperator"></param>
+        /// <returns></returns>
+        public TableQueryBuilder CombineFilters(TableOperator tableOperator)
+        {
+            AppendTableOperator(tableOperator);
+            return this;
+        }
+
+        /// <summary>
+        /// Begins a group of filters.
+        /// </summary>
+        /// <returns></returns>
+        public TableQueryBuilder BeginGroup()
+        {
+            AppendBeginGroup();
+            return this;
+        }
+
+        /// <summary>
+        /// Ends a group of filters.
+        /// </summary>
+        /// <returns></returns>
+        public TableQueryBuilder EndGroup()
+        {     
+            AppendEndGroup();
+            return this;
+        }
+
+        /// <summary>
+        /// Groups all filters.
+        /// </summary>
+        /// <returns></returns>
+        public TableQueryBuilder GroupAll()
+        {
+            PrependAppendGroupAll();
+            return this;
+        }
+
+        private void AppendBeginGroup()
+        {
+            _queryBuilder.Append('(');
+            _beginGroupCount++;
+        }
+
+        private void AppendEndGroup()
+        {
+            ThrowIfNoFilter();
+            _queryBuilder.Append(')');
+            _endGroupCount++;
+        }
+
+        private void PrependAppendGroupAll()
+        {
+            ThrowIfNoFilter();
+            _queryBuilder.Insert(0, '(');
+            _beginGroupCount++;
+            AppendEndGroup();
+        }
+
+        private void AppendTableOperator(TableOperator tableOperator)
+        {
+            ThrowIfNoFilter();
+            _queryBuilder.Append($" {TableOperators.GetOperator(tableOperator)} ");
+        }
+
+        private void ThrowIfNoFilter()
+        {
+            if (!HasFilter)
+            {
+                throw new InvalidOperationException($"No filter has been added to the query. Add a filter condition using .{nameof(AddFilter)} method.");
+            }
+        }
+
+        /// <summary>
+        /// Emits a string for Odata Azure Table Storage query
+        /// </summary>
+        /// <returns>Returns an Odata Azure Table Storage query or an empty string</returns>
+        public override string ToString()
+        {
+            return _queryBuilder.ToString();
+        }
+    }
+}
+#endif

--- a/src/ElCamino.Azure.Data.Tables/TableQueryBuilder.cs
+++ b/src/ElCamino.Azure.Data.Tables/TableQueryBuilder.cs
@@ -18,7 +18,7 @@ namespace ElCamino.Azure.Data.Tables
         /// </summary>
         public TableQueryBuilder() { }
 
-        private StringBuilder _queryBuilder = new StringBuilder();
+        private readonly StringBuilder _queryBuilder = new();
         private uint _filterCount = 0;
         private uint _beginGroupCount = 0;
         private uint _endGroupCount = 0;

--- a/src/ElCamino.Identity.AzureTable.DataUtility/ClaimMigrateRowkey.cs
+++ b/src/ElCamino.Identity.AzureTable.DataUtility/ClaimMigrateRowkey.cs
@@ -70,7 +70,7 @@ namespace ElCamino.Identity.AzureTable.DataUtility
 
                     var claimNew = new TableEntity(claim);
                     claimNew.ResetKeys(claim.PartitionKey,
-                        _keyHelper.GenerateRowKeyIdentityUserClaim(claim["ClaimType"].ToString(), claim["ClaimValue"].ToString()),
+                        _keyHelper.GenerateRowKeyIdentityUserClaim(claim["ClaimType"].ToString(), claim["ClaimValue"].ToString()).ToString(),
                          TableConstants.ETagWildcard);
                     if (claimNew.ContainsKey(KeyVersion))
                     {

--- a/src/ElCamino.Identity.AzureTable.DataUtility/ClaimMigrateRowkey.cs
+++ b/src/ElCamino.Identity.AzureTable.DataUtility/ClaimMigrateRowkey.cs
@@ -21,15 +21,15 @@ namespace ElCamino.Identity.AzureTable.DataUtility
         public TableQuery GetSourceTableQuery()
         {
             TableQuery tq = new TableQuery();
-            string partitionFilter = TableQuery.CombineFilters(
+            var partitionFilter = TableQuery.CombineFilters(
                 TableQuery.GenerateFilterCondition("PartitionKey", QueryComparisons.GreaterThanOrEqual, _keyHelper.PreFixIdentityUserId),
                 TableOperators.And,
                 TableQuery.GenerateFilterCondition("PartitionKey", QueryComparisons.LessThan, _keyHelper.PreFixIdentityUserIdUpperBound));
-            string rowFilter = TableQuery.CombineFilters(
+            var rowFilter = TableQuery.CombineFilters(
                 TableQuery.GenerateFilterCondition("RowKey", QueryComparisons.GreaterThanOrEqual, _keyHelper.PreFixIdentityUserClaim),
                 TableOperators.And,
                 TableQuery.GenerateFilterCondition("RowKey", QueryComparisons.LessThan, _keyHelper.PreFixIdentityUserClaimUpperBound));
-            tq.FilterString = TableQuery.CombineFilters(partitionFilter, TableOperators.And, rowFilter);
+            tq.FilterString = TableQuery.CombineFilters(partitionFilter, TableOperators.And, rowFilter).ToString();
             return tq;
         }
 

--- a/src/ElCamino.Identity.AzureTable.DataUtility/ClaimMigrateRowkey.cs
+++ b/src/ElCamino.Identity.AzureTable.DataUtility/ClaimMigrateRowkey.cs
@@ -41,7 +41,7 @@ namespace ElCamino.Identity.AzureTable.DataUtility
 
             if (!string.IsNullOrWhiteSpace(claimType))
             {
-                return (d.RowKey != _keyHelper.GenerateRowKeyIdentityUserClaim(claimType, claimValue ?? string.Empty));
+                return (!d.RowKey.AsSpan().Equals(_keyHelper.GenerateRowKeyIdentityUserClaim(claimType, claimValue), StringComparison.OrdinalIgnoreCase));
             }
 
             return false;

--- a/src/ElCamino.Identity.AzureTable.DataUtility/ElCamino.Identity.AzureTable.DataUtility.csproj
+++ b/src/ElCamino.Identity.AzureTable.DataUtility/ElCamino.Identity.AzureTable.DataUtility.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
-    <LangVersion>12.0</LangVersion>
+    <TargetFramework>net9.0</TargetFramework>
+    <LangVersion>13.0</LangVersion>
     <AssemblyName>ElCamino.Identity.AzureTable.DataUtility</AssemblyName>
     <OutputType>Exe</OutputType>
     <PackageId>ElCamino.Identity.AzureTable.DataUtility</PackageId>
@@ -10,7 +10,7 @@
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
     <EnableDefaultContentItems>false</EnableDefaultContentItems>
-    <Version>8.0</Version>
+    <Version>9.0</Version>
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
@@ -41,11 +41,11 @@
 
   <ItemGroup>
     <PackageReference Include="Azure.Data.Tables" Version="12.8.1" />
-    <PackageReference Include="Microsoft.Extensions.Identity.Core" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Identity.Stores" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Identity.Core" Version="9.0.*" />
+    <PackageReference Include="Microsoft.Extensions.Identity.Stores" Version="9.0.*" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.*" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.*" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="9.0.*" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ElCamino.Identity.AzureTable.DataUtility/EmailMigrateIndex.cs
+++ b/src/ElCamino.Identity.AzureTable.DataUtility/EmailMigrateIndex.cs
@@ -21,7 +21,7 @@ namespace ElCamino.Identity.AzureTable.DataUtility
         public TableQuery GetSourceTableQuery()
         {
             TableQuery tq = new TableQuery();
-            tq.SelectColumns = new List<string>() { "PartitionKey", "RowKey", "Email" };
+            tq.SelectColumns = [ "PartitionKey", "RowKey", "Email" ];
             var partitionFilter = TableQuery.CombineFilters(
                 TableQuery.GenerateFilterCondition("PartitionKey", QueryComparisons.GreaterThanOrEqual, _keyHelper.PreFixIdentityUserId),
                 TableOperators.And,

--- a/src/ElCamino.Identity.AzureTable.DataUtility/EmailMigrateIndex.cs
+++ b/src/ElCamino.Identity.AzureTable.DataUtility/EmailMigrateIndex.cs
@@ -22,15 +22,15 @@ namespace ElCamino.Identity.AzureTable.DataUtility
         {
             TableQuery tq = new TableQuery();
             tq.SelectColumns = new List<string>() { "PartitionKey", "RowKey", "Email" };
-            string partitionFilter = TableQuery.CombineFilters(
+            var partitionFilter = TableQuery.CombineFilters(
                 TableQuery.GenerateFilterCondition("PartitionKey", QueryComparisons.GreaterThanOrEqual, _keyHelper.PreFixIdentityUserId),
                 TableOperators.And,
                 TableQuery.GenerateFilterCondition("PartitionKey", QueryComparisons.LessThan, _keyHelper.PreFixIdentityUserIdUpperBound));
-            string rowFilter = TableQuery.CombineFilters(
+            var rowFilter = TableQuery.CombineFilters(
                 TableQuery.GenerateFilterCondition("RowKey", QueryComparisons.GreaterThanOrEqual, _keyHelper.PreFixIdentityUserId),
                 TableOperators.And,
                 TableQuery.GenerateFilterCondition("RowKey", QueryComparisons.LessThan, _keyHelper.PreFixIdentityUserIdUpperBound));
-            tq.FilterString = TableQuery.CombineFilters(partitionFilter, TableOperators.And, rowFilter);
+            tq.FilterString = TableQuery.CombineFilters(partitionFilter, TableOperators.And, rowFilter).ToString();
             return tq;
         }
 

--- a/src/ElCamino.Identity.AzureTable.DataUtility/EmailMigrateIndex.cs
+++ b/src/ElCamino.Identity.AzureTable.DataUtility/EmailMigrateIndex.cs
@@ -83,7 +83,7 @@ namespace ElCamino.Identity.AzureTable.DataUtility
             return new IdentityUserIndex()
             {
                 Id = userid,
-                PartitionKey = _keyHelper.GenerateRowKeyUserEmail(email),
+                PartitionKey = _keyHelper.GenerateRowKeyUserEmail(email).ToString(),
                 RowKey = userid,
                 KeyVersion = _keyHelper.KeyVersion,
                 ETag = TableConstants.ETagWildcard

--- a/src/ElCamino.Identity.AzureTable.DataUtility/LoginMigrateIndex.cs
+++ b/src/ElCamino.Identity.AzureTable.DataUtility/LoginMigrateIndex.cs
@@ -22,15 +22,15 @@ namespace ElCamino.Identity.AzureTable.DataUtility
         {
             TableQuery tq = new TableQuery();
             tq.SelectColumns = new List<string>() { "PartitionKey", "RowKey", "LoginProvider", "ProviderKey" };
-            string partitionFilter = TableQuery.CombineFilters(
+            var partitionFilter = TableQuery.CombineFilters(
                 TableQuery.GenerateFilterCondition("PartitionKey", QueryComparisons.GreaterThanOrEqual, _keyHelper.PreFixIdentityUserId),
                 TableOperators.And,
                 TableQuery.GenerateFilterCondition("PartitionKey", QueryComparisons.LessThan, _keyHelper.PreFixIdentityUserIdUpperBound));
-            string rowFilter = TableQuery.CombineFilters(
+            var rowFilter = TableQuery.CombineFilters(
                 TableQuery.GenerateFilterCondition("RowKey", QueryComparisons.GreaterThanOrEqual, _keyHelper.PreFixIdentityUserLogin),
                 TableOperators.And,
                 TableQuery.GenerateFilterCondition("RowKey", QueryComparisons.LessThan, _keyHelper.PreFixIdentityUserLoginUpperBound));
-            tq.FilterString = TableQuery.CombineFilters(partitionFilter, TableOperators.And, rowFilter);
+            tq.FilterString = TableQuery.CombineFilters(partitionFilter, TableOperators.And, rowFilter).ToString();
             return tq;
         }
 

--- a/src/ElCamino.Identity.AzureTable.DataUtility/LoginMigrateIndex.cs
+++ b/src/ElCamino.Identity.AzureTable.DataUtility/LoginMigrateIndex.cs
@@ -21,7 +21,7 @@ namespace ElCamino.Identity.AzureTable.DataUtility
         public TableQuery GetSourceTableQuery()
         {
             TableQuery tq = new TableQuery();
-            tq.SelectColumns = new List<string>() { "PartitionKey", "RowKey", "LoginProvider", "ProviderKey" };
+            tq.SelectColumns = ["PartitionKey", "RowKey", "LoginProvider", "ProviderKey"];
             var partitionFilter = TableQuery.CombineFilters(
                 TableQuery.GenerateFilterCondition("PartitionKey", QueryComparisons.GreaterThanOrEqual, _keyHelper.PreFixIdentityUserId),
                 TableOperators.And,

--- a/src/ElCamino.Identity.AzureTable.DataUtility/LoginMigrateIndex.cs
+++ b/src/ElCamino.Identity.AzureTable.DataUtility/LoginMigrateIndex.cs
@@ -83,7 +83,7 @@ namespace ElCamino.Identity.AzureTable.DataUtility
             return new IdentityUserIndex()
             {
                 Id = userid,
-                PartitionKey = _keyHelper.GeneratePartitionKeyIndexByLogin(loginProvider, providerKey),
+                PartitionKey = _keyHelper.GeneratePartitionKeyIndexByLogin(loginProvider, providerKey).ToString(),
                 RowKey = _keyHelper.GenerateRowKeyIdentityUserLogin(loginProvider, providerKey),
                 KeyVersion = _keyHelper.KeyVersion,
                 ETag = TableConstants.ETagWildcard

--- a/src/ElCamino.Identity.AzureTable.DataUtility/LoginMigrateIndex.cs
+++ b/src/ElCamino.Identity.AzureTable.DataUtility/LoginMigrateIndex.cs
@@ -84,7 +84,7 @@ namespace ElCamino.Identity.AzureTable.DataUtility
             {
                 Id = userid,
                 PartitionKey = _keyHelper.GeneratePartitionKeyIndexByLogin(loginProvider, providerKey).ToString(),
-                RowKey = _keyHelper.GenerateRowKeyIdentityUserLogin(loginProvider, providerKey),
+                RowKey = _keyHelper.GenerateRowKeyIdentityUserLogin(loginProvider, providerKey).ToString(),
                 KeyVersion = _keyHelper.KeyVersion,
                 ETag = TableConstants.ETagWildcard
             };

--- a/src/ElCamino.Identity.AzureTable.DataUtility/Program.cs
+++ b/src/ElCamino.Identity.AzureTable.DataUtility/Program.cs
@@ -19,15 +19,15 @@ namespace ElCamino.Identity.AzureTable.DataUtility
         private static int iUserTotal = 0;
         private static int iUserSuccessConvert = 0;
         private static int iUserFailureConvert = 0;
-        private static readonly ConcurrentBag<string> userIdFailures = new();
+        private static readonly ConcurrentBag<string> userIdFailures = [];
 
-        private static readonly List<string> helpTokens = new() { "/?", "/help" };
+        private static readonly List<string> helpTokens = ["/?", "/help"];
         private const string PreviewToken = "/preview:";
         private const string MigrateToken = "/migrate:";
-        private static readonly List<string> validCommands = new() {
+        private static readonly List<string> validCommands = [
             MigrationFactory.Roles,
             MigrationFactory.Users
-        };
+        ];
         private const string NoDeleteToken = "/nodelete";
         private const string MaxDegreesParallelToken = "/maxparallel:";
         private static int iMaxdegreesparallel = Environment.ProcessorCount * 2;
@@ -129,7 +129,7 @@ namespace ElCamino.Identity.AzureTable.DataUtility
                 {
                     if (migrateOption)
                     {
-                        migration.ProcessMigrate(targetContext, sourceContext, sourceResults?.Values.ToList()??new List<TableEntity>(), iMaxdegreesparallel,
+                        migration.ProcessMigrate(targetContext, sourceContext, sourceResults?.Values.ToList() ?? [], iMaxdegreesparallel,
                         () =>
                         {
                             Interlocked.Increment(ref iUserSuccessConvert);
@@ -201,7 +201,7 @@ namespace ElCamino.Identity.AzureTable.DataUtility
             }
             else
             {
-                List<string> nonHelpTokens = new List<string>() { PreviewToken, MigrateToken, NoDeleteToken, MaxDegreesParallelToken, StartPageToken, FinishPageToken, PageSizeToken };
+                List<string> nonHelpTokens = [PreviewToken, MigrateToken, NoDeleteToken, MaxDegreesParallelToken, StartPageToken, FinishPageToken, PageSizeToken];
                 if (!args.All(a => nonHelpTokens.Any(h => a.StartsWith(h, StringComparison.OrdinalIgnoreCase))))
                 {
                     DisplayInvalidArgs(args.Where(a => !nonHelpTokens.Any(h => h.StartsWith(a, StringComparison.OrdinalIgnoreCase))).ToList());
@@ -211,13 +211,13 @@ namespace ElCamino.Identity.AzureTable.DataUtility
                 bool isMigrate = args.Any(a => a.StartsWith(MigrateToken, StringComparison.OrdinalIgnoreCase));
                 if (isPreview && isMigrate)
                 {
-                    DisplayInvalidArgs(new List<string>() { PreviewToken, MigrateToken, "Cannot define /preview and /migrate. Only one can be used." });
+                    DisplayInvalidArgs([PreviewToken, MigrateToken, "Cannot define /preview and /migrate. Only one can be used."]);
                     return false;
                 }
                 bool isNoDelete = args.Any(a => a.Equals(NoDeleteToken, StringComparison.OrdinalIgnoreCase));
                 if (isNoDelete && !isMigrate)
                 {
-                    DisplayInvalidArgs(new List<string>() { NoDeleteToken, "/nodelete must be used with /migrate option." });
+                    DisplayInvalidArgs([NoDeleteToken, "/nodelete must be used with /migrate option."]);
                     return false;
                 }
 
@@ -241,7 +241,7 @@ namespace ElCamino.Identity.AzureTable.DataUtility
 
                 if (iPageSize > 1000)
                 {
-                    DisplayInvalidArgs(new List<string>() { PageSizeToken, string.Format("{0} must be less than 1000", PageSizeToken) });
+                    DisplayInvalidArgs([PageSizeToken, string.Format("{0} must be less than 1000", PageSizeToken)]);
                     return false;
                 }
                 migrateOption = isMigrate;
@@ -264,7 +264,7 @@ namespace ElCamino.Identity.AzureTable.DataUtility
                 }
                 else
                 {
-                    DisplayInvalidArgs(new List<string>() { args, string.Format("{0} must be followed by an int greater than 0. e.g. {0}3", token) });
+                    DisplayInvalidArgs([args, string.Format("{0} must be followed by an int greater than 0. e.g. {0}3", token)]);
                     return false;
                 }
             }
@@ -284,7 +284,7 @@ namespace ElCamino.Identity.AzureTable.DataUtility
                 }
                 else
                 {
-                    DisplayInvalidArgs(new List<string>() { args, string.Format("{0} must be followed by a valid command arg {1}", token, string.Join(",", validCommands.ToArray())) });
+                    DisplayInvalidArgs([args, string.Format("{0} must be followed by a valid command arg {1}", token, string.Join(",", validCommands.ToArray()))]);
                     return false;
                 }
             }

--- a/src/ElCamino.Identity.AzureTable.DataUtility/Program.cs
+++ b/src/ElCamino.Identity.AzureTable.DataUtility/Program.cs
@@ -59,14 +59,14 @@ namespace ElCamino.Identity.AzureTable.DataUtility
 
             IdentityConfiguration sourceConfig = new IdentityConfiguration();
             sourceConfig.TablePrefix = Configuration.GetSection("source:IdentityConfiguration:TablePrefix")?.Value;
-            sourceConfig.StorageConnectionString = Configuration.GetSection("source:IdentityConfiguration:StorageConnectionString")?.Value;
+            string sourceStorageConnectionString = Configuration.GetSection("source:IdentityConfiguration:StorageConnectionString")?.Value ?? string.Empty;
             sourceConfig.UserTableName = Configuration.GetSection("source:IdentityConfiguration:UserTableName")?.Value ?? string.Empty;
             sourceConfig.IndexTableName = Configuration.GetSection("source:IdentityConfiguration:IndexTableName")?.Value ?? string.Empty;
             sourceConfig.RoleTableName = Configuration.GetSection("source:IdentityConfiguration:RoleTableName")?.Value ?? string.Empty;
 
             IdentityConfiguration targetConfig = new IdentityConfiguration();
             targetConfig.TablePrefix = Configuration.GetSection("target:IdentityConfiguration:TablePrefix")?.Value;
-            targetConfig.StorageConnectionString = Configuration.GetSection("target:IdentityConfiguration:StorageConnectionString")?.Value;
+            string targetStorageConnectionString = Configuration.GetSection("target:IdentityConfiguration:StorageConnectionString")?.Value ?? string.Empty;
             targetConfig.UserTableName = Configuration.GetSection("target:IdentityConfiguration:UserTableName")?.Value ?? string.Empty;
             targetConfig.IndexTableName = Configuration.GetSection("target:IdentityConfiguration:IndexTableName")?.Value ?? string.Empty;
             targetConfig.RoleTableName = Configuration.GetSection("target:IdentityConfiguration:RoleTableName")?.Value ?? string.Empty;
@@ -77,7 +77,7 @@ namespace ElCamino.Identity.AzureTable.DataUtility
             Console.WriteLine("MigrateCommand: {0}", MigrateCommand);
 
             var migration = MigrationFactory.CreateMigration(MigrateCommand);
-            IdentityCloudContext targetContext = new IdentityCloudContext(targetConfig);
+            IdentityCloudContext targetContext = new IdentityCloudContext(targetConfig, new TableServiceClient(targetStorageConnectionString));
             
             Task.WhenAll(targetContext.IndexTable.CreateIfNotExistsAsync(),
                         targetContext.UserTable.CreateIfNotExistsAsync(),
@@ -88,7 +88,7 @@ namespace ElCamino.Identity.AzureTable.DataUtility
 
             string entityRecordName = "Users";
 
-            IdentityCloudContext sourceContext = new IdentityCloudContext(sourceConfig);
+            IdentityCloudContext sourceContext = new IdentityCloudContext(sourceConfig, new TableServiceClient(sourceStorageConnectionString));
             Console.WriteLine($"Source IndexTable: {sourceConfig.IndexTableName}");
             Console.WriteLine($"Source UserTable: {sourceConfig.UserTableName}");
             Console.WriteLine($"Source RoleTable: {sourceConfig.RoleTableName}");

--- a/src/ElCamino.Identity.AzureTable.DataUtility/RoleAndClaimMigrateIndex.cs
+++ b/src/ElCamino.Identity.AzureTable.DataUtility/RoleAndClaimMigrateIndex.cs
@@ -21,7 +21,7 @@ namespace ElCamino.Identity.AzureTable.DataUtility
         public TableQuery GetSourceTableQuery()
         {
             TableQuery tq = new TableQuery();
-            tq.SelectColumns = new List<string>() { "PartitionKey", "RowKey", "KeyVersion" };
+            tq.SelectColumns = ["PartitionKey", "RowKey", "KeyVersion"];
             var partitionFilter = TableQuery.CombineFilters(
                 TableQuery.GenerateFilterCondition("PartitionKey", QueryComparisons.GreaterThanOrEqual, _keyHelper.PreFixIdentityUserId),
                 TableOperators.And,

--- a/src/ElCamino.Identity.AzureTable.DataUtility/RoleAndClaimMigrateIndex.cs
+++ b/src/ElCamino.Identity.AzureTable.DataUtility/RoleAndClaimMigrateIndex.cs
@@ -22,24 +22,24 @@ namespace ElCamino.Identity.AzureTable.DataUtility
         {
             TableQuery tq = new TableQuery();
             tq.SelectColumns = new List<string>() { "PartitionKey", "RowKey", "KeyVersion" };
-            string partitionFilter = TableQuery.CombineFilters(
+            var partitionFilter = TableQuery.CombineFilters(
                 TableQuery.GenerateFilterCondition("PartitionKey", QueryComparisons.GreaterThanOrEqual, _keyHelper.PreFixIdentityUserId),
                 TableOperators.And,
                 TableQuery.GenerateFilterCondition("PartitionKey", QueryComparisons.LessThan, _keyHelper.PreFixIdentityUserIdUpperBound));
-            string rowFilterRole = TableQuery.CombineFilters(
+            var rowFilterRole = TableQuery.CombineFilters(
                 TableQuery.GenerateFilterCondition("RowKey", QueryComparisons.GreaterThanOrEqual, _keyHelper.PreFixIdentityUserRole),
                 TableOperators.And,
                 TableQuery.GenerateFilterCondition("RowKey", QueryComparisons.LessThan, _keyHelper.PreFixIdentityUserRoleUpperBound));
-            string rowFilterClaim = TableQuery.CombineFilters(
+            var rowFilterClaim = TableQuery.CombineFilters(
                 TableQuery.GenerateFilterCondition("RowKey", QueryComparisons.GreaterThanOrEqual, _keyHelper.PreFixIdentityUserClaim),
                 TableOperators.And,
                 TableQuery.GenerateFilterCondition("RowKey", QueryComparisons.LessThan, _keyHelper.PreFixIdentityUserClaimUpperBound));
 
-            string keyVersionFilter = TableQuery.GenerateFilterConditionForDouble("KeyVersion", QueryComparisons.LessThan, 2.0);
+            var keyVersionFilter = TableQuery.GenerateFilterConditionForDouble("KeyVersion", QueryComparisons.LessThan, 2.0);
 
-            string rowFilter = TableQuery.CombineFilters(rowFilterRole, TableOperators.Or, rowFilterClaim);
-            string keysFilter = TableQuery.CombineFilters(partitionFilter, TableOperators.And, rowFilter);
-            tq.FilterString = TableQuery.CombineFilters(keysFilter, TableOperators.And, keyVersionFilter);
+            var rowFilter = TableQuery.CombineFilters(rowFilterRole, TableOperators.Or, rowFilterClaim);
+            var keysFilter = TableQuery.CombineFilters(partitionFilter, TableOperators.And, rowFilter);
+            tq.FilterString = TableQuery.CombineFilters(keysFilter, TableOperators.And, keyVersionFilter).ToString();
             return tq;
         }
 

--- a/src/ElCamino.Identity.AzureTable.DataUtility/RolesMigration.cs
+++ b/src/ElCamino.Identity.AzureTable.DataUtility/RolesMigration.cs
@@ -83,8 +83,8 @@ namespace ElCamino.Identity.AzureTable.DataUtility
                 string? roleName = GetRoleNameBySourceId(sourceEntity.PartitionKey, sourcesContext);
 
                 targetEntity = new TableEntity(sourceEntity);
-                targetEntity.ResetKeys(_keyHelper.GenerateRowKeyIdentityRole(roleName),
-                    _keyHelper.GenerateRowKeyIdentityRoleClaim(claimType, claimValue), TableConstants.ETagWildcard);
+                targetEntity.ResetKeys(_keyHelper.GenerateRowKeyIdentityRole(roleName).ToString(),
+                    _keyHelper.GenerateRowKeyIdentityRoleClaim(claimType, claimValue).ToString(), TableConstants.ETagWildcard);
                 targetEntity["KeyVersion"] = _keyHelper.KeyVersion;
             }
             else if (sourceEntity.RowKey.StartsWith(_keyHelper.PreFixIdentityRole))
@@ -93,7 +93,7 @@ namespace ElCamino.Identity.AzureTable.DataUtility
                 string? roleName = roleNameProperty?.ToString();
 
                 targetEntity = new TableEntity(sourceEntity);
-                targetEntity.ResetKeys(_keyHelper.GeneratePartitionKeyIdentityRole(roleName), _keyHelper.GenerateRowKeyIdentityRole(roleName), TableConstants.ETagWildcard);
+                targetEntity.ResetKeys(_keyHelper.GeneratePartitionKeyIdentityRole(roleName), _keyHelper.GenerateRowKeyIdentityRole(roleName).ToString(), TableConstants.ETagWildcard);
                 targetEntity["KeyVersion"] = _keyHelper.KeyVersion;
 
             }

--- a/src/ElCamino.Identity.AzureTable.DataUtility/RolesMigration.cs
+++ b/src/ElCamino.Identity.AzureTable.DataUtility/RolesMigration.cs
@@ -93,7 +93,9 @@ namespace ElCamino.Identity.AzureTable.DataUtility
                 string? roleName = roleNameProperty?.ToString();
 
                 targetEntity = new TableEntity(sourceEntity);
-                targetEntity.ResetKeys(_keyHelper.GeneratePartitionKeyIdentityRole(roleName), _keyHelper.GenerateRowKeyIdentityRole(roleName).ToString(), TableConstants.ETagWildcard);
+                targetEntity.ResetKeys(_keyHelper.GeneratePartitionKeyIdentityRole(roleName).ToString(), 
+                    _keyHelper.GenerateRowKeyIdentityRole(roleName).ToString(), 
+                    TableConstants.ETagWildcard);
                 targetEntity["KeyVersion"] = _keyHelper.KeyVersion;
 
             }

--- a/src/ElCamino.Identity.AzureTable.DataUtility/RolesMigration.cs
+++ b/src/ElCamino.Identity.AzureTable.DataUtility/RolesMigration.cs
@@ -54,7 +54,7 @@ namespace ElCamino.Identity.AzureTable.DataUtility
         {
             var tr = sourcesContext.RoleTable.GetEntityOrDefaultAsync<TableEntity>(
                 _keyHelper.ParsePartitionKeyIdentityRoleFromRowKey(roleRowKey),
-                roleRowKey, new List<string>() { nameof(IdentityRole.Name), nameof(TableEntity.PartitionKey), nameof(TableEntity.RowKey) }).Result;
+                roleRowKey, [nameof(IdentityRole.Name), nameof(TableEntity.PartitionKey), nameof(TableEntity.RowKey)]).Result;
 
             if (tr != null)
             {

--- a/src/ElCamino.Identity.AzureTable.DataUtility/RolesMigration.cs
+++ b/src/ElCamino.Identity.AzureTable.DataUtility/RolesMigration.cs
@@ -21,9 +21,9 @@ namespace ElCamino.Identity.AzureTable.DataUtility
         {
             //Get all User key records
             TableQuery tq = new TableQuery();
-            string keyVersionFilter = TableQuery.GenerateFilterConditionForDouble("KeyVersion", QueryComparisons.LessThan, _keyHelper.KeyVersion);
+            var keyVersionFilter = TableQuery.GenerateFilterConditionForDouble("KeyVersion", QueryComparisons.LessThan, _keyHelper.KeyVersion);
 
-            tq.FilterString = keyVersionFilter;
+            tq.FilterString = keyVersionFilter.ToString();
             return tq;
         }
 

--- a/src/ElCamino.Identity.AzureTable.DataUtility/RolesMigration.cs
+++ b/src/ElCamino.Identity.AzureTable.DataUtility/RolesMigration.cs
@@ -53,7 +53,7 @@ namespace ElCamino.Identity.AzureTable.DataUtility
         private string? GetRoleNameBySourceId(string roleRowKey, IdentityCloudContext sourcesContext)
         {
             var tr = sourcesContext.RoleTable.GetEntityOrDefaultAsync<TableEntity>(
-                _keyHelper.ParsePartitionKeyIdentityRoleFromRowKey(roleRowKey),
+                _keyHelper.ParsePartitionKeyIdentityRoleFromRowKey(roleRowKey).ToString(),
                 roleRowKey, [nameof(IdentityRole.Name), nameof(TableEntity.PartitionKey), nameof(TableEntity.RowKey)]).Result;
 
             if (tr != null)

--- a/src/ElCamino.Identity.AzureTable.DataUtility/UsersMigration.cs
+++ b/src/ElCamino.Identity.AzureTable.DataUtility/UsersMigration.cs
@@ -172,9 +172,9 @@ namespace ElCamino.Identity.AzureTable.DataUtility
                         sourceEntity.TryGetValue("ProviderKey", out object providerKeyProperty);
                         string? providerKey = providerKeyProperty?.ToString();
 
-                        string targetUserRowKey = _keyHelper.GenerateRowKeyIdentityUserLogin(loginProvider, providerKey);
+                        var targetUserRowKey = _keyHelper.GenerateRowKeyIdentityUserLogin(loginProvider, providerKey);
                         TableEntity tgtDte = new TableEntity(sourceEntity);
-                        tgtDte.ResetKeys(targetUserPartitionKey.ToString(), targetUserRowKey, TableConstants.ETagWildcard);
+                        tgtDte.ResetKeys(targetUserPartitionKey.ToString(), targetUserRowKey.ToString(), TableConstants.ETagWildcard);
                         tgtDte["UserId"] = userId;
                         tgtDte["KeyVersion"] = _keyHelper.KeyVersion;
                         targetUserEntities.Add(tgtDte);
@@ -187,7 +187,7 @@ namespace ElCamino.Identity.AzureTable.DataUtility
                             {
                                 Id = targetUserPartitionKey.ToString(),
                                 PartitionKey = _keyHelper.GeneratePartitionKeyIndexByLogin(loginProvider, providerKey).ToString(),
-                                RowKey = _keyHelper.GenerateRowKeyIdentityUserLogin(loginProvider, providerKey),
+                                RowKey = _keyHelper.GenerateRowKeyIdentityUserLogin(loginProvider, providerKey).ToString(),
                                 KeyVersion = _keyHelper.KeyVersion,
                                 ETag = TableConstants.ETagWildcard
                             };

--- a/src/ElCamino.Identity.AzureTable.DataUtility/UsersMigration.cs
+++ b/src/ElCamino.Identity.AzureTable.DataUtility/UsersMigration.cs
@@ -203,9 +203,9 @@ namespace ElCamino.Identity.AzureTable.DataUtility
                         sourceEntity.TryGetValue(nameof(IdentityUserRole<string>.RoleName), out object roleNameProperty);
                         string? roleName = roleNameProperty?.ToString();
 
-                        string targetUserRowKey = _keyHelper.GenerateRowKeyIdentityUserRole(roleName);
+                        var targetUserRowKey = _keyHelper.GenerateRowKeyIdentityUserRole(roleName);
                         TableEntity tgtDte = new TableEntity(sourceEntity);
-                        tgtDte.ResetKeys(targetUserPartitionKey.ToString(), targetUserRowKey, TableConstants.ETagWildcard);
+                        tgtDte.ResetKeys(targetUserPartitionKey.ToString(), targetUserRowKey.ToString(), TableConstants.ETagWildcard);
                         tgtDte["UserId"] = userId;
                         tgtDte["KeyVersion"] = _keyHelper.KeyVersion;
                         targetUserEntities.Add(tgtDte);
@@ -214,7 +214,7 @@ namespace ElCamino.Identity.AzureTable.DataUtility
                         IdentityUserIndex roleIndex = new IdentityUserIndex()
                         {
                             Id = targetUserPartitionKey.ToString(),
-                            PartitionKey = targetUserRowKey,
+                            PartitionKey = targetUserRowKey.ToString(),
                             RowKey = targetUserPartitionKey.ToString(),
                             KeyVersion = _keyHelper.KeyVersion,
                             ETag = TableConstants.ETagWildcard

--- a/src/ElCamino.Identity.AzureTable.DataUtility/UsersMigration.cs
+++ b/src/ElCamino.Identity.AzureTable.DataUtility/UsersMigration.cs
@@ -90,7 +90,7 @@ namespace ElCamino.Identity.AzureTable.DataUtility
             {
                 if (sourceEntity.PartitionKey.StartsWith(_keyHelper.PreFixIdentityUserId))
                 {
-                    string targetUserPartitionKey = _keyHelper.GenerateRowKeyUserId(userId);
+                    var targetUserPartitionKey = _keyHelper.GenerateRowKeyUserId(userId);
 
                     //User record
                     if (sourceEntity.RowKey.StartsWith(_keyHelper.PreFixIdentityUserId))
@@ -99,7 +99,7 @@ namespace ElCamino.Identity.AzureTable.DataUtility
                         //Add UserName Index
                         //Add Email Index
                         TableEntity tgtDte = new TableEntity(sourceEntity);
-                        tgtDte.ResetKeys(targetUserPartitionKey, targetUserPartitionKey, TableConstants.ETagWildcard);
+                        tgtDte.ResetKeys(targetUserPartitionKey.ToString(), targetUserPartitionKey.ToString(), TableConstants.ETagWildcard);
                         tgtDte["Id"] = userId;
                         tgtDte["KeyVersion"] = _keyHelper.KeyVersion;
                         targetUserEntities.Add(tgtDte);
@@ -109,9 +109,9 @@ namespace ElCamino.Identity.AzureTable.DataUtility
                         var userNameKey = _keyHelper.GenerateRowKeyUserName(userNameProperty.ToString());
                         IdentityUserIndex userNameIndex = new IdentityUserIndex()
                         {
-                            Id = targetUserPartitionKey,
+                            Id = targetUserPartitionKey.ToString(),
                             PartitionKey = userNameKey.ToString(),
-                            RowKey = targetUserPartitionKey,
+                            RowKey = targetUserPartitionKey.ToString(),
                             KeyVersion = _keyHelper.KeyVersion,
                             ETag = TableConstants.ETagWildcard
                         };
@@ -123,9 +123,9 @@ namespace ElCamino.Identity.AzureTable.DataUtility
                             var emailKey = _keyHelper.GenerateRowKeyUserEmail(emailProperty.ToString());
                             IdentityUserIndex emailIndex = new IdentityUserIndex()
                             {
-                                Id = targetUserPartitionKey,
+                                Id = targetUserPartitionKey.ToString(),
                                 PartitionKey = emailKey.ToString(),
-                                RowKey = targetUserPartitionKey,
+                                RowKey = targetUserPartitionKey.ToString(),
                                 KeyVersion = _keyHelper.KeyVersion,
                                 ETag = TableConstants.ETagWildcard
                             };
@@ -145,7 +145,7 @@ namespace ElCamino.Identity.AzureTable.DataUtility
 
                         string targetUserRowKey = _keyHelper.GenerateRowKeyIdentityUserClaim(claimType, claimValue);
                         TableEntity tgtDte = new TableEntity(sourceEntity);
-                        tgtDte.ResetKeys(targetUserPartitionKey, targetUserRowKey, TableConstants.ETagWildcard);
+                        tgtDte.ResetKeys(targetUserPartitionKey.ToString(), targetUserRowKey, TableConstants.ETagWildcard);
                         tgtDte["UserId"] = userId;
                         tgtDte["KeyVersion"] = _keyHelper.KeyVersion;
                         targetUserEntities.Add(tgtDte);
@@ -153,9 +153,9 @@ namespace ElCamino.Identity.AzureTable.DataUtility
                         //Claim index
                         IdentityUserIndex claimIndex = new IdentityUserIndex()
                         {
-                            Id = targetUserPartitionKey,
+                            Id = targetUserPartitionKey.ToString(),
                             PartitionKey = targetUserRowKey,
-                            RowKey = targetUserPartitionKey,
+                            RowKey = targetUserPartitionKey.ToString(),
                             KeyVersion = _keyHelper.KeyVersion,
                             ETag = TableConstants.ETagWildcard
                         };
@@ -174,7 +174,7 @@ namespace ElCamino.Identity.AzureTable.DataUtility
 
                         string targetUserRowKey = _keyHelper.GenerateRowKeyIdentityUserLogin(loginProvider, providerKey);
                         TableEntity tgtDte = new TableEntity(sourceEntity);
-                        tgtDte.ResetKeys(targetUserPartitionKey, targetUserRowKey, TableConstants.ETagWildcard);
+                        tgtDte.ResetKeys(targetUserPartitionKey.ToString(), targetUserRowKey, TableConstants.ETagWildcard);
                         tgtDte["UserId"] = userId;
                         tgtDte["KeyVersion"] = _keyHelper.KeyVersion;
                         targetUserEntities.Add(tgtDte);
@@ -185,7 +185,7 @@ namespace ElCamino.Identity.AzureTable.DataUtility
                         {
                             IdentityUserIndex logonIndex = new IdentityUserIndex()
                             {
-                                Id = targetUserPartitionKey,
+                                Id = targetUserPartitionKey.ToString(),
                                 PartitionKey = _keyHelper.GeneratePartitionKeyIndexByLogin(loginProvider, providerKey).ToString(),
                                 RowKey = _keyHelper.GenerateRowKeyIdentityUserLogin(loginProvider, providerKey),
                                 KeyVersion = _keyHelper.KeyVersion,
@@ -205,7 +205,7 @@ namespace ElCamino.Identity.AzureTable.DataUtility
 
                         string targetUserRowKey = _keyHelper.GenerateRowKeyIdentityUserRole(roleName);
                         TableEntity tgtDte = new TableEntity(sourceEntity);
-                        tgtDte.ResetKeys(targetUserPartitionKey, targetUserRowKey, TableConstants.ETagWildcard);
+                        tgtDte.ResetKeys(targetUserPartitionKey.ToString(), targetUserRowKey, TableConstants.ETagWildcard);
                         tgtDte["UserId"] = userId;
                         tgtDte["KeyVersion"] = _keyHelper.KeyVersion;
                         targetUserEntities.Add(tgtDte);
@@ -213,9 +213,9 @@ namespace ElCamino.Identity.AzureTable.DataUtility
                         //Role index
                         IdentityUserIndex roleIndex = new IdentityUserIndex()
                         {
-                            Id = targetUserPartitionKey,
+                            Id = targetUserPartitionKey.ToString(),
                             PartitionKey = targetUserRowKey,
-                            RowKey = targetUserPartitionKey,
+                            RowKey = targetUserPartitionKey.ToString(),
                             KeyVersion = _keyHelper.KeyVersion,
                             ETag = TableConstants.ETagWildcard
                         };
@@ -236,7 +236,7 @@ namespace ElCamino.Identity.AzureTable.DataUtility
                         {
                             string targetUserRowKey = _keyHelper.GenerateRowKeyIdentityUserToken(loginProvider, tokenName);
                             TableEntity tgtDte = new TableEntity(sourceEntity);
-                            tgtDte.ResetKeys(targetUserPartitionKey, targetUserRowKey, TableConstants.ETagWildcard);
+                            tgtDte.ResetKeys(targetUserPartitionKey.ToString(), targetUserRowKey, TableConstants.ETagWildcard);
                             tgtDte["UserId"] = userId;
                             tgtDte["KeyVersion"] = _keyHelper.KeyVersion;
                             targetUserEntities.Add(tgtDte);

--- a/src/ElCamino.Identity.AzureTable.DataUtility/UsersMigration.cs
+++ b/src/ElCamino.Identity.AzureTable.DataUtility/UsersMigration.cs
@@ -234,9 +234,9 @@ namespace ElCamino.Identity.AzureTable.DataUtility
                         if (!string.IsNullOrWhiteSpace(loginProvider) 
                             && !string.IsNullOrWhiteSpace(tokenName))
                         {
-                            string targetUserRowKey = _keyHelper.GenerateRowKeyIdentityUserToken(loginProvider, tokenName);
+                            var targetUserRowKey = _keyHelper.GenerateRowKeyIdentityUserToken(loginProvider, tokenName);
                             TableEntity tgtDte = new TableEntity(sourceEntity);
-                            tgtDte.ResetKeys(targetUserPartitionKey.ToString(), targetUserRowKey, TableConstants.ETagWildcard);
+                            tgtDte.ResetKeys(targetUserPartitionKey.ToString(), targetUserRowKey.ToString(), TableConstants.ETagWildcard);
                             tgtDte["UserId"] = userId;
                             tgtDte["KeyVersion"] = _keyHelper.KeyVersion;
                             targetUserEntities.Add(tgtDte);

--- a/src/ElCamino.Identity.AzureTable.DataUtility/UsersMigration.cs
+++ b/src/ElCamino.Identity.AzureTable.DataUtility/UsersMigration.cs
@@ -22,7 +22,7 @@ namespace ElCamino.Identity.AzureTable.DataUtility
         {
             //Get all User key records
             TableQuery tq = new TableQuery();
-            tq.SelectColumns = new List<string>() { "PartitionKey", "RowKey", "KeyVersion" };
+            tq.SelectColumns = ["PartitionKey", "RowKey", "KeyVersion"];
             var partitionFilter = TableQuery.CombineFilters(
                 TableQuery.GenerateFilterCondition("PartitionKey", QueryComparisons.GreaterThanOrEqual, _keyHelper.PreFixIdentityUserId),
                 TableOperators.And,
@@ -79,7 +79,7 @@ namespace ElCamino.Identity.AzureTable.DataUtility
             var keyVersionFilter = TableQuery.GenerateFilterConditionForDouble("KeyVersion", QueryComparisons.LessThan, _keyHelper.KeyVersion);
             tq.FilterString = TableQuery.CombineFilters(partitionKeyFilter, TableOperators.And, keyVersionFilter).ToString();
             var r = sourcesContext.UserTable.Query<TableEntity>(tq.FilterString);
-            return r.ToList();
+            return [.. r];
         }
 
         private (List<TableEntity> targetUserEntities, List<IdentityUserIndex> targetUserIndexes) ConvertToTargetUserEntities(string userId, List<TableEntity> sourceUserEntities)

--- a/src/ElCamino.Identity.AzureTable.DataUtility/UsersMigration.cs
+++ b/src/ElCamino.Identity.AzureTable.DataUtility/UsersMigration.cs
@@ -120,11 +120,11 @@ namespace ElCamino.Identity.AzureTable.DataUtility
                         //Email index - only if email exists
                         if (tgtDte.TryGetValue("Email", out object emailProperty))
                         {
-                            string emailKey = _keyHelper.GenerateRowKeyUserEmail(emailProperty.ToString());
+                            var emailKey = _keyHelper.GenerateRowKeyUserEmail(emailProperty.ToString());
                             IdentityUserIndex emailIndex = new IdentityUserIndex()
                             {
                                 Id = targetUserPartitionKey,
-                                PartitionKey = emailKey,
+                                PartitionKey = emailKey.ToString(),
                                 RowKey = targetUserPartitionKey,
                                 KeyVersion = _keyHelper.KeyVersion,
                                 ETag = TableConstants.ETagWildcard

--- a/src/ElCamino.Identity.AzureTable.DataUtility/UsersMigration.cs
+++ b/src/ElCamino.Identity.AzureTable.DataUtility/UsersMigration.cs
@@ -106,11 +106,11 @@ namespace ElCamino.Identity.AzureTable.DataUtility
 
                         //UserName index
                         tgtDte.TryGetValue("UserName", out object userNameProperty);
-                        string userNameKey = _keyHelper.GenerateRowKeyUserName(userNameProperty.ToString());
+                        var userNameKey = _keyHelper.GenerateRowKeyUserName(userNameProperty.ToString());
                         IdentityUserIndex userNameIndex = new IdentityUserIndex()
                         {
                             Id = targetUserPartitionKey,
-                            PartitionKey = userNameKey,
+                            PartitionKey = userNameKey.ToString(),
                             RowKey = targetUserPartitionKey,
                             KeyVersion = _keyHelper.KeyVersion,
                             ETag = TableConstants.ETagWildcard

--- a/src/ElCamino.Identity.AzureTable.DataUtility/UsersMigration.cs
+++ b/src/ElCamino.Identity.AzureTable.DataUtility/UsersMigration.cs
@@ -46,7 +46,7 @@ namespace ElCamino.Identity.AzureTable.DataUtility
                 try
                 {
                     var sourceUserEntities = GetUserEntitiesBySourceId(dte.PartitionKey, sourceContext);
-                    string targetUserId = _keyHelper.GenerateUserId();
+                    string targetUserId = _keyHelper.GenerateUserId().ToString();
                     var targetEntities = ConvertToTargetUserEntities(targetUserId, sourceUserEntities);
                     List<Task> mainTasks = new List<Task>(2);
                     List<Task> indexTasks = new List<Task>(100);

--- a/src/ElCamino.Identity.AzureTable.DataUtility/UsersMigration.cs
+++ b/src/ElCamino.Identity.AzureTable.DataUtility/UsersMigration.cs
@@ -186,7 +186,7 @@ namespace ElCamino.Identity.AzureTable.DataUtility
                             IdentityUserIndex logonIndex = new IdentityUserIndex()
                             {
                                 Id = targetUserPartitionKey,
-                                PartitionKey = _keyHelper.GeneratePartitionKeyIndexByLogin(loginProvider, providerKey),
+                                PartitionKey = _keyHelper.GeneratePartitionKeyIndexByLogin(loginProvider, providerKey).ToString(),
                                 RowKey = _keyHelper.GenerateRowKeyIdentityUserLogin(loginProvider, providerKey),
                                 KeyVersion = _keyHelper.KeyVersion,
                                 ETag = TableConstants.ETagWildcard

--- a/src/ElCamino.Identity.AzureTable.DataUtility/UsersMigration.cs
+++ b/src/ElCamino.Identity.AzureTable.DataUtility/UsersMigration.cs
@@ -143,9 +143,9 @@ namespace ElCamino.Identity.AzureTable.DataUtility
                         sourceEntity.TryGetValue("ClaimValue", out object claimValueProperty);
                         string? claimValue = claimValueProperty?.ToString();
 
-                        string targetUserRowKey = _keyHelper.GenerateRowKeyIdentityUserClaim(claimType, claimValue);
+                        var targetUserRowKey = _keyHelper.GenerateRowKeyIdentityUserClaim(claimType, claimValue);
                         TableEntity tgtDte = new TableEntity(sourceEntity);
-                        tgtDte.ResetKeys(targetUserPartitionKey.ToString(), targetUserRowKey, TableConstants.ETagWildcard);
+                        tgtDte.ResetKeys(targetUserPartitionKey.ToString(), targetUserRowKey.ToString(), TableConstants.ETagWildcard);
                         tgtDte["UserId"] = userId;
                         tgtDte["KeyVersion"] = _keyHelper.KeyVersion;
                         targetUserEntities.Add(tgtDte);
@@ -154,7 +154,7 @@ namespace ElCamino.Identity.AzureTable.DataUtility
                         IdentityUserIndex claimIndex = new IdentityUserIndex()
                         {
                             Id = targetUserPartitionKey.ToString(),
-                            PartitionKey = targetUserRowKey,
+                            PartitionKey = targetUserRowKey.ToString(),
                             RowKey = targetUserPartitionKey.ToString(),
                             KeyVersion = _keyHelper.KeyVersion,
                             ETag = TableConstants.ETagWildcard

--- a/src/ElCamino.Identity.AzureTable.DataUtility/UsersMigration.cs
+++ b/src/ElCamino.Identity.AzureTable.DataUtility/UsersMigration.cs
@@ -23,18 +23,18 @@ namespace ElCamino.Identity.AzureTable.DataUtility
             //Get all User key records
             TableQuery tq = new TableQuery();
             tq.SelectColumns = new List<string>() { "PartitionKey", "RowKey", "KeyVersion" };
-            string partitionFilter = TableQuery.CombineFilters(
+            var partitionFilter = TableQuery.CombineFilters(
                 TableQuery.GenerateFilterCondition("PartitionKey", QueryComparisons.GreaterThanOrEqual, _keyHelper.PreFixIdentityUserId),
                 TableOperators.And,
                 TableQuery.GenerateFilterCondition("PartitionKey", QueryComparisons.LessThan, _keyHelper.PreFixIdentityUserIdUpperBound));
-            string rowFilter = TableQuery.CombineFilters(
+            var rowFilter = TableQuery.CombineFilters(
                 TableQuery.GenerateFilterCondition("RowKey", QueryComparisons.GreaterThanOrEqual, _keyHelper.PreFixIdentityUserId),
                 TableOperators.And,
                 TableQuery.GenerateFilterCondition("RowKey", QueryComparisons.LessThan, _keyHelper.PreFixIdentityUserIdUpperBound));
-            string keyVersionFilter = TableQuery.GenerateFilterConditionForDouble("KeyVersion", QueryComparisons.LessThan, _keyHelper.KeyVersion);
-            string keysFilter = TableQuery.CombineFilters(partitionFilter, TableOperators.And, rowFilter);
+            var keyVersionFilter = TableQuery.GenerateFilterConditionForDouble("KeyVersion", QueryComparisons.LessThan, _keyHelper.KeyVersion);
+            var keysFilter = TableQuery.CombineFilters(partitionFilter, TableOperators.And, rowFilter);
 
-            tq.FilterString = TableQuery.CombineFilters(keysFilter, TableOperators.And, keyVersionFilter);
+            tq.FilterString = TableQuery.CombineFilters(keysFilter, TableOperators.And, keyVersionFilter).ToString();
             return tq;
         }
 
@@ -75,9 +75,9 @@ namespace ElCamino.Identity.AzureTable.DataUtility
         private List<TableEntity> GetUserEntitiesBySourceId(string userPartitionKey, IdentityCloudContext sourcesContext)
         {
             TableQuery tq = new TableQuery();
-            string partitionKeyFilter = TableQuery.GenerateFilterCondition("PartitionKey", QueryComparisons.Equal, userPartitionKey);
-            string keyVersionFilter = TableQuery.GenerateFilterConditionForDouble("KeyVersion", QueryComparisons.LessThan, _keyHelper.KeyVersion);
-            tq.FilterString = TableQuery.CombineFilters(partitionKeyFilter, TableOperators.And, keyVersionFilter);
+            var partitionKeyFilter = TableQuery.GenerateFilterCondition("PartitionKey", QueryComparisons.Equal, userPartitionKey);
+            var keyVersionFilter = TableQuery.GenerateFilterConditionForDouble("KeyVersion", QueryComparisons.LessThan, _keyHelper.KeyVersion);
+            tq.FilterString = TableQuery.CombineFilters(partitionKeyFilter, TableOperators.And, keyVersionFilter).ToString();
             var r = sourcesContext.UserTable.Query<TableEntity>(tq.FilterString);
             return r.ToList();
         }

--- a/tests/ElCamino.AspNetCore.Identity.AzureTable.Tests/BaseRoleStoreTests.cs
+++ b/tests/ElCamino.AspNetCore.Identity.AzureTable.Tests/BaseRoleStoreTests.cs
@@ -5,6 +5,7 @@ using System.Diagnostics;
 using System.Linq;
 using System.Security.Claims;
 using System.Threading.Tasks;
+using Azure.Data.Tables;
 using ElCamino.AspNetCore.Identity.AzureTable.Model;
 using ElCamino.Web.Identity.AzureTable.Tests.Fixtures;
 using Microsoft.AspNetCore.Identity;
@@ -110,10 +111,9 @@ namespace ElCamino.AspNetCore.Identity.AzureTable.Tests
             ServiceCollection services = new ServiceCollection();
             // Adding coverage for CreateAzureTablesIfNotExists();
             services.AddIdentityCore<IdentityUser>()
-                .AddAzureTableStores<IdentityCloudContext>(new Func<IdentityConfiguration>(() =>
-                {
-                    return roleFixture.GetConfig();
-                }), roleFixture.GetKeyHelper())
+                .AddAzureTableStores<IdentityCloudContext>(() => roleFixture.GetConfig().config 
+                , () => new TableServiceClient(roleFixture.GetConfig().connectionString)
+                , roleFixture.GetKeyHelper())
                 .CreateAzureTablesIfNotExists<IdentityCloudContext>();
 
         }

--- a/tests/ElCamino.AspNetCore.Identity.AzureTable.Tests/BaseUserStoreTests.Properties.partial.cs
+++ b/tests/ElCamino.AspNetCore.Identity.AzureTable.Tests/BaseUserStoreTests.Properties.partial.cs
@@ -239,6 +239,18 @@ namespace ElCamino.AspNetCore.Identity.AzureTable.Tests
 
             await Assert.ThrowsAsync<ArgumentNullException>(() => store.GetTwoFactorEnabledAsync(null)).ConfigureAwait(false);
             await Assert.ThrowsAsync<ArgumentNullException>(() => store.SetTwoFactorEnabledAsync(null, twoFactorEnabled)).ConfigureAwait(false);
+
+            var recoveryCodes = await manager.GenerateNewTwoFactorRecoveryCodesAsync(user, 10);
+            recoveryCodes.ToList().ForEach(rc => _output.WriteLine($"Recovery Code: {rc}"));
+            Assert.Equal(10, recoveryCodes.Count());
+
+            string recoveryCode = recoveryCodes.First();
+            var redeemptionResult = await manager.RedeemTwoFactorRecoveryCodeAsync(user, recoveryCode);
+            Assert.True(redeemptionResult.Succeeded, string.Concat(redeemptionResult.Errors));
+            _output.WriteLine($"Redeemed Code: {recoveryCode}");
+
+            int codeCount = await manager.CountRecoveryCodesAsync(user);
+            Assert.Equal(9, codeCount);
         }
 
         public virtual async Task PasswordHash()

--- a/tests/ElCamino.AspNetCore.Identity.AzureTable.Tests/BaseUserStoreTests.Properties.partial.cs
+++ b/tests/ElCamino.AspNetCore.Identity.AzureTable.Tests/BaseUserStoreTests.Properties.partial.cs
@@ -91,8 +91,8 @@ namespace ElCamino.AspNetCore.Identity.AzureTable.Tests
             else
             {
                 var selectColumns = new List<string>() { nameof(IdentityUserIndex.Id) };
-                string filterString = TableQuery.GenerateFilterCondition(nameof(IdentityUserIndex.Id), QueryComparisons.Equal, user.Id);
-                var results = await store.Context.IndexTable.QueryAsync<TableEntity>(filter: filterString, select: selectColumns).ToListAsync().ConfigureAwait(false);
+                var filterString = TableQuery.GenerateFilterCondition(nameof(IdentityUserIndex.Id), QueryComparisons.Equal, user.Id);
+                var results = await store.Context.IndexTable.QueryAsync<TableEntity>(filter: filterString.ToString(), select: selectColumns).ToListAsync().ConfigureAwait(false);
                 Assert.DoesNotContain(results, (x) => x.RowKey.StartsWith(AzureTable.TableConstants.RowKeyConstants.PreFixIdentityUserEmail)); //, string.Format("Email index not deleted for user {0}", user.Id));
             }
             //Should not find old by old email.

--- a/tests/ElCamino.AspNetCore.Identity.AzureTable.Tests/BaseUserStoreTests.Properties.partial.cs
+++ b/tests/ElCamino.AspNetCore.Identity.AzureTable.Tests/BaseUserStoreTests.Properties.partial.cs
@@ -64,7 +64,7 @@ namespace ElCamino.AspNetCore.Identity.AzureTable.Tests
             Assert.True(resetAccessFailedCountResult.Succeeded, string.Concat(resetAccessFailedCountResult.Errors));
 
             user = await manager.FindByIdAsync(user.Id).ConfigureAwait(false);
-            Assert.True(user.AccessFailedCount == 0);
+            Assert.Equal<int>(0, user.AccessFailedCount);
 
             await Assert.ThrowsAsync<ArgumentNullException>(() => store.GetAccessFailedCountAsync(null)).ConfigureAwait(false);
             await Assert.ThrowsAsync<ArgumentNullException>(() => store.IncrementAccessFailedCountAsync(null)).ConfigureAwait(false);

--- a/tests/ElCamino.AspNetCore.Identity.AzureTable.Tests/BaseUserStoreTests.cs
+++ b/tests/ElCamino.AspNetCore.Identity.AzureTable.Tests/BaseUserStoreTests.cs
@@ -9,7 +9,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Azure.Data.Tables;
 using ElCamino.AspNetCore.Identity.AzureTable.Model;
-using ElCamino.Web.Identity.AzureTable.Tests.Fixtures;
+using ElCamino.AspNetCore.Identity.AzureTable.Tests.Fixtures;
 using ElCamino.Web.Identity.AzureTable.Tests.ModelTests;
 using Microsoft.AspNetCore.Identity;
 using Xunit;
@@ -44,7 +44,7 @@ namespace ElCamino.AspNetCore.Identity.AzureTable.Tests
 
                 if (userRole == null)
                 {
-                    var r = (TRole)Activator.CreateInstance(typeof(TRole), new object[1] { roleName });
+                    var r = (TRole)Activator.CreateInstance(typeof(TRole), [roleName]);
 
                     await rstore.CreateAsync(r).ConfigureAwait(false);
                 }
@@ -65,7 +65,7 @@ namespace ElCamino.AspNetCore.Identity.AzureTable.Tests
 
             using (RoleStore<TRole> rstore = userFixture.CreateRoleStore())
             {
-                var r = (TRole)Activator.CreateInstance(typeof(TRole), new object[1] { roleName });
+                var r = (TRole)Activator.CreateInstance(typeof(TRole), [roleName]);
                 await rstore.CreateAsync(r).ConfigureAwait(false);
                 await rstore.FindByNameAsync(roleName).ConfigureAwait(false);
             }
@@ -131,7 +131,7 @@ namespace ElCamino.AspNetCore.Identity.AzureTable.Tests
         protected override async Task<T> CreateTestUserAsync<T>(bool createPassword = true, bool createEmail = true,
             string emailAddress = null)
         {
-            string strValidConnection = userFixture.GetConfig().StorageConnectionString;
+            string strValidConnection = userFixture.GetConfig().connectionString;
 
             using var store = userFixture.CreateUserStore();
             using var manager = userFixture.CreateUserManager();
@@ -559,7 +559,7 @@ namespace ElCamino.AspNetCore.Identity.AzureTable.Tests
         protected virtual async Task<T> CreateTestUserAsync<T>(bool createPassword = true, bool createEmail = true,
             string emailAddress = null) where T : Model.IdentityUser<string>, new()
         {
-            string strValidConnection = userFixture.GetConfig().StorageConnectionString;
+            string strValidConnection = userFixture.GetConfig().connectionString;
 
             using var store = userFixture.CreateUserStore();
             using var manager = userFixture.CreateUserManager();

--- a/tests/ElCamino.AspNetCore.Identity.AzureTable.Tests/ElCamino.AspNetCore.Identity.AzureTable.Tests.csproj
+++ b/tests/ElCamino.AspNetCore.Identity.AzureTable.Tests/ElCamino.AspNetCore.Identity.AzureTable.Tests.csproj
@@ -3,11 +3,11 @@
   <PropertyGroup>
     <Description>Testing</Description>
     <Authors>David Melendez</Authors>
-    <TargetFrameworks>net8.0</TargetFrameworks>
-    <LangVersion>12.0</LangVersion>
+    <TargetFrameworks>net9.0</TargetFrameworks>
+    <LangVersion>13.0</LangVersion>
     <AssemblyName>ElCamino.AspNetCore.Identity.AzureTable.Tests</AssemblyName>
     <IsPackable>false</IsPackable>
-    <Version>8.0</Version>
+    <Version>9.0</Version>
     <Nullable>disable</Nullable>
     <DebugType>Full</DebugType>
 
@@ -32,14 +32,14 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.Identity.Core" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Identity.Stores" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="8.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.DataProtection" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Identity.Core" Version="9.0.*" />
+    <PackageReference Include="Microsoft.Extensions.Identity.Stores" Version="9.0.*" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.*" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.*" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="9.0.*" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="9.0.*" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="9.0.*" />
+    <PackageReference Include="Microsoft.AspNetCore.DataProtection" Version="9.0.*" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/ElCamino.AspNetCore.Identity.AzureTable.Tests/ElCamino.AspNetCore.Identity.AzureTable.Tests.csproj
+++ b/tests/ElCamino.AspNetCore.Identity.AzureTable.Tests/ElCamino.AspNetCore.Identity.AzureTable.Tests.csproj
@@ -28,7 +28,7 @@
     <ProjectReference Include="..\..\src\ElCamino.AspNetCore.Identity.AzureTable\ElCamino.AspNetCore.Identity.AzureTable.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="6.0.1">
+    <PackageReference Include="coverlet.collector" Version="6.0.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
@@ -44,11 +44,11 @@
 
   <ItemGroup>
     <PackageReference Include="Azure.Data.Tables" Version="12.8.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="xunit" Version="2.7.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
     <PackageReference Include="System.Diagnostics.TraceSource" Version="4.3.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.7">
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/tests/ElCamino.AspNetCore.Identity.AzureTable.Tests/Fakes/HashTestKeyHelperFake.cs
+++ b/tests/ElCamino.AspNetCore.Identity.AzureTable.Tests/Fakes/HashTestKeyHelperFake.cs
@@ -12,7 +12,7 @@ namespace ElCamino.AspNetCore.Identity.AzureTable.Tests.Fakes
 {
     internal class HashTestKeyHelperFake : BaseKeyHelper
     {
-        public override string ConvertKeyToHash(string input)
+        public override ReadOnlySpan<char> ConvertKeyToHash(ReadOnlySpan<char> input)
         {
             throw new NotImplementedException();
         }

--- a/tests/ElCamino.AspNetCore.Identity.AzureTable.Tests/Fixtures/BaseFixture.cs
+++ b/tests/ElCamino.AspNetCore.Identity.AzureTable.Tests/Fixtures/BaseFixture.cs
@@ -160,7 +160,6 @@ namespace ElCamino.AspNetCore.Identity.AzureTable.Tests.Fixtures
 
             var idconfig = new IdentityConfiguration()
             {
-                StorageConnectionString = root["IdentityAzureTable:identityConfiguration:storageConnectionString"],
                 TablePrefix = root["IdentityAzureTable:identityConfiguration:tablePrefix"],
                 IndexTableName = root["IdentityAzureTable:identityConfiguration:indexTableName"],
                 UserTableName = root["IdentityAzureTable:identityConfiguration:userTableName"],

--- a/tests/ElCamino.AspNetCore.Identity.AzureTable.Tests/Fixtures/BaseFixture.cs
+++ b/tests/ElCamino.AspNetCore.Identity.AzureTable.Tests/Fixtures/BaseFixture.cs
@@ -1,20 +1,22 @@
 ﻿// MIT License Copyright 2020 (c) David Melendez. All rights reserved. See License.txt in the project root for license information.
 
 using System;
+using Azure.Data.Tables;
 using ElCamino.AspNetCore.Identity.AzureTable;
 using ElCamino.AspNetCore.Identity.AzureTable.Model;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Identity;
+using Microsoft.Extensions.Azure;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using IdentityRole = ElCamino.AspNetCore.Identity.AzureTable.Model.IdentityRole;
 using IdentityUser = ElCamino.AspNetCore.Identity.AzureTable.Model.IdentityUser<string>;
 using Model = ElCamino.AspNetCore.Identity.AzureTable.Model;
 
-namespace ElCamino.Web.Identity.AzureTable.Tests.Fixtures
+namespace ElCamino.AspNetCore.Identity.AzureTable.Tests.Fixtures
 {
     public class BaseFixture<TUser, TRole, TContext, TUserStore, TKeyHelper>
-        : BaseFixture<TUser, TContext, string, Model.IdentityUserClaim, Model.IdentityUserLogin, Model.IdentityUserToken, TUserStore, TKeyHelper>
+        : BaseFixture<TUser, TContext, string, IdentityUserClaim, IdentityUserLogin, IdentityUserToken, TUserStore, TKeyHelper>
         where TUser : IdentityUser, new()
         where TRole : IdentityRole, new()
         where TContext : IdentityCloudContext
@@ -51,10 +53,9 @@ namespace ElCamino.Web.Identity.AzureTable.Tests.Fixtures
             id.AddRoles<IdentityRole>();
 
 
-            id = id.AddAzureTableStores<TContext>(new Func<IdentityConfiguration>(() =>
-            {
-                return GetConfig();
-            }), GetKeyHelper());
+            id = id.AddAzureTableStores<TContext>(() => GetConfig().config
+            , () => new TableServiceClient(GetConfig().connectionString)
+            , GetKeyHelper());
 
 
             id.CreateAzureTablesIfNotExists<TContext>();
@@ -84,10 +85,9 @@ namespace ElCamino.Web.Identity.AzureTable.Tests.Fixtures
             //Add the role here to load the correct UserStore
             id.AddRoles<IdentityRole>();
 
-            id = id.AddAzureTableStores<TContext>(new Func<IdentityConfiguration>(() =>
-            {
-                return GetConfig();
-            }), GetKeyHelper());
+            id = id.AddAzureTableStores<TContext>(() => GetConfig().config
+            , () => new TableServiceClient(GetConfig().connectionString)
+            , GetKeyHelper());
 
             id.Services.AddDataProtection();
             id.AddDefaultTokenProviders();
@@ -102,10 +102,10 @@ namespace ElCamino.Web.Identity.AzureTable.Tests.Fixtures
     }
 
     public class BaseFixture<TUser, TContext, TUserStore, TKeyHelper>
-    : BaseFixture<TUser, TContext, string, Model.IdentityUserClaim, Model.IdentityUserLogin, Model.IdentityUserToken, TUserStore, TKeyHelper>
+    : BaseFixture<TUser, TContext, string, IdentityUserClaim, IdentityUserLogin, IdentityUserToken, TUserStore, TKeyHelper>
     where TUser : IdentityUser, new()
     where TContext : IdentityCloudContext
-    where TUserStore : UserOnlyStore<TUser, TContext, string, Model.IdentityUserClaim, Model.IdentityUserLogin, Model.IdentityUserToken>
+    where TUserStore : UserOnlyStore<TUser, TContext, string, IdentityUserClaim, IdentityUserLogin, IdentityUserToken>
     where TKeyHelper : IKeyHelper, new()
     {
 
@@ -151,7 +151,7 @@ namespace ElCamino.Web.Identity.AzureTable.Tests.Fixtures
             return new TKeyHelper();
         }
 
-        public IdentityConfiguration GetConfig()
+        public (IdentityConfiguration config, string connectionString) GetConfig()
         {
             var configuration = new ConfigurationBuilder()
                 .AddJsonFile("config.json", reloadOnChange: true, optional: false);
@@ -167,17 +167,17 @@ namespace ElCamino.Web.Identity.AzureTable.Tests.Fixtures
                 RoleTableName = root["IdentityAzureTable:identityConfiguration:roleTableName"]
             };
 
-            return idconfig;
+            return (config: idconfig, connectionString: root["IdentityAzureTable:identityConfiguration:storageConnectionString"]);
         }
 
         public TContext GetContext()
         {
-            return GetContext(GetConfig());
+            return GetContext(GetConfig().config, new TableServiceClient(GetConfig().connectionString));
         }
 
-        public TContext GetContext(IdentityConfiguration config)
+        public TContext GetContext(IdentityConfiguration config, TableServiceClient client)
         {
-            return Activator.CreateInstance(typeof(TContext), new object[1] { config }) as TContext;
+            return Activator.CreateInstance(typeof(TContext), [config, client]) as TContext;
 
         }
 
@@ -188,7 +188,7 @@ namespace ElCamino.Web.Identity.AzureTable.Tests.Fixtures
 
         public TUserStore CreateUserStore(TContext context)
         {
-            var userStore = Activator.CreateInstance(typeof(TUserStore), new object[2] { context, GetKeyHelper() }) as TUserStore;
+            var userStore = Activator.CreateInstance(typeof(TUserStore), [context, GetKeyHelper()]) as TUserStore;
 
             return userStore;
         }
@@ -209,10 +209,9 @@ namespace ElCamino.Web.Identity.AzureTable.Tests.Fixtures
             });
 
 
-            id = id.AddAzureTableStores<TContext>(new Func<IdentityConfiguration>(() =>
-            {
-                return GetConfig();
-            }), GetKeyHelper());
+            id = id.AddAzureTableStores<TContext>(() => GetConfig().config
+            , () => new TableServiceClient(GetConfig().connectionString)
+            , GetKeyHelper());
 
             id.Services.AddDataProtection();
             id.AddDefaultTokenProviders();

--- a/tests/ElCamino.AspNetCore.Identity.AzureTable.Tests/Fixtures/RoleFixture.cs
+++ b/tests/ElCamino.AspNetCore.Identity.AzureTable.Tests/Fixtures/RoleFixture.cs
@@ -2,6 +2,7 @@
 
 using ElCamino.AspNetCore.Identity.AzureTable;
 using ElCamino.AspNetCore.Identity.AzureTable.Model;
+using ElCamino.AspNetCore.Identity.AzureTable.Tests.Fixtures;
 using IdentityRole = ElCamino.AspNetCore.Identity.AzureTable.Model.IdentityRole;
 
 namespace ElCamino.Web.Identity.AzureTable.Tests.Fixtures

--- a/tests/ElCamino.AspNetCore.Identity.AzureTable.Tests/Fixtures/UserFixture.cs
+++ b/tests/ElCamino.AspNetCore.Identity.AzureTable.Tests/Fixtures/UserFixture.cs
@@ -2,6 +2,7 @@
 
 using ElCamino.AspNetCore.Identity.AzureTable;
 using ElCamino.AspNetCore.Identity.AzureTable.Model;
+using ElCamino.AspNetCore.Identity.AzureTable.Tests.Fixtures;
 using ElCamino.Web.Identity.AzureTable.Tests.ModelTests;
 using IdentityUser = ElCamino.AspNetCore.Identity.AzureTable.Model.IdentityUser<string>;
 using Model = ElCamino.AspNetCore.Identity.AzureTable.Model;

--- a/tests/ElCamino.AspNetCore.Identity.AzureTable.Tests/KeyHelperTests.cs
+++ b/tests/ElCamino.AspNetCore.Identity.AzureTable.Tests/KeyHelperTests.cs
@@ -84,10 +84,20 @@ namespace ElCamino.AspNetCore.Identity.AzureTable.Tests
 
             sw.Reset();
             sw.Start();
-            returned = _sha256KeyHelper.GenerateRowKeyUserId(textToHash);
+            try
+            {
+                returned = _sha256KeyHelper.GenerateRowKeyUserId(textToHash);
+            }
+            catch (ArgumentNullException)
+            {
+                returned = null;
+            }
             sw.Stop();
             _output.WriteLine($"returned {sw.Elapsed.TotalMilliseconds} ms: {returned}");
-            Assert.StartsWith(TableConstants.RowKeyConstants.PreFixIdentityUserId, returned, StringComparison.InvariantCulture);
+            if (returned is not null)
+            {
+                Assert.StartsWith(TableConstants.RowKeyConstants.PreFixIdentityUserId, returned, StringComparison.InvariantCulture);
+            }
         }
     }
 }

--- a/tests/ElCamino.AspNetCore.Identity.AzureTable.Tests/KeyHelperTests.cs
+++ b/tests/ElCamino.AspNetCore.Identity.AzureTable.Tests/KeyHelperTests.cs
@@ -41,7 +41,7 @@ namespace ElCamino.AspNetCore.Identity.AzureTable.Tests
 
             sw.Reset();
             sw.Start();
-            string returned = _defaultKeyHelper.ConvertKeyToHash(textToHash);
+            string returned = _defaultKeyHelper.ConvertKeyToHash(textToHash).ToString();
             sw.Stop();
             _output.WriteLine($"returned {sw.Elapsed.TotalMilliseconds} ms: {returned}");
             Assert.Equal(expected, returned, StringComparer.InvariantCulture);
@@ -62,7 +62,7 @@ namespace ElCamino.AspNetCore.Identity.AzureTable.Tests
 
             sw.Reset();
             sw.Start();
-            string returned = _sha256KeyHelper.ConvertKeyToHash(textToHash);
+            string returned = _sha256KeyHelper.ConvertKeyToHash(textToHash).ToString();
             sw.Stop();
             _output.WriteLine($"returned {sw.Elapsed.TotalMilliseconds} ms: {returned}");
             Assert.Equal(expected, returned, StringComparer.InvariantCulture);

--- a/tests/ElCamino.AspNetCore.Identity.AzureTable.Tests/KeyHelperTests.cs
+++ b/tests/ElCamino.AspNetCore.Identity.AzureTable.Tests/KeyHelperTests.cs
@@ -80,7 +80,7 @@ namespace ElCamino.AspNetCore.Identity.AzureTable.Tests
             var returned = _defaultKeyHelper.GenerateRowKeyUserId(textToHash);
             sw.Stop();
             _output.WriteLine($"returned {sw.Elapsed.TotalMilliseconds} ms: {returned}");
-            Assert.StartsWith(TableConstants.RowKeyConstants.PreFixIdentityUserId, returned, StringComparison.InvariantCulture);
+            Assert.StartsWith(TableConstants.RowKeyConstants.PreFixIdentityUserId, returned, StringComparison.OrdinalIgnoreCase);
 
             sw.Reset();
             sw.Start();
@@ -96,7 +96,7 @@ namespace ElCamino.AspNetCore.Identity.AzureTable.Tests
             _output.WriteLine($"returned {sw.Elapsed.TotalMilliseconds} ms: {returned}");
             if (!returned.IsEmpty)
             {
-                Assert.StartsWith(TableConstants.RowKeyConstants.PreFixIdentityUserId, returned, StringComparison.InvariantCulture);
+                Assert.StartsWith(TableConstants.RowKeyConstants.PreFixIdentityUserId, returned, StringComparison.OrdinalIgnoreCase);
             }
         }
     }

--- a/tests/ElCamino.AspNetCore.Identity.AzureTable.Tests/KeyHelperTests.cs
+++ b/tests/ElCamino.AspNetCore.Identity.AzureTable.Tests/KeyHelperTests.cs
@@ -77,7 +77,7 @@ namespace ElCamino.AspNetCore.Identity.AzureTable.Tests
             _output.WriteLine($"plain text: {textToHash}");
             var sw = new Stopwatch();
             sw.Start();
-            string returned = _defaultKeyHelper.GenerateRowKeyUserId(textToHash);
+            var returned = _defaultKeyHelper.GenerateRowKeyUserId(textToHash);
             sw.Stop();
             _output.WriteLine($"returned {sw.Elapsed.TotalMilliseconds} ms: {returned}");
             Assert.StartsWith(TableConstants.RowKeyConstants.PreFixIdentityUserId, returned, StringComparison.InvariantCulture);
@@ -94,7 +94,7 @@ namespace ElCamino.AspNetCore.Identity.AzureTable.Tests
             }
             sw.Stop();
             _output.WriteLine($"returned {sw.Elapsed.TotalMilliseconds} ms: {returned}");
-            if (returned is not null)
+            if (!returned.IsEmpty)
             {
                 Assert.StartsWith(TableConstants.RowKeyConstants.PreFixIdentityUserId, returned, StringComparison.InvariantCulture);
             }

--- a/tests/ElCamino.AspNetCore.Identity.AzureTable.Tests/ModelTests/IdentityCloudContextTests.cs
+++ b/tests/ElCamino.AspNetCore.Identity.AzureTable.Tests/ModelTests/IdentityCloudContextTests.cs
@@ -20,7 +20,7 @@ namespace ElCamino.AspNetCore.Identity.AzureTable.Tests.ModelTests
         [Trait("IdentityCore.Azure.Model", "")]
         public void IdentityCloudContextCtors()
         {
-            Assert.Throws<ArgumentNullException>(() => new IdentityCloudContext(null));
+            Assert.Throws<ArgumentNullException>(() => new IdentityCloudContext(null, null));
             var locConfig = roleFixture.GetConfig();
             //LocationMode is deprecated
             //locConfig.LocationMode = "invalidMode";
@@ -33,7 +33,7 @@ namespace ElCamino.AspNetCore.Identity.AzureTable.Tests.ModelTests
             var tContext = new IdentityCloudContext(tableConfig, client);
 
             tableConfig.TablePrefix = "a";
-            tContext = new IdentityCloudContext(tableConfig);
+            tContext = new IdentityCloudContext(tableConfig, client);
             //Covers Client get
             Assert.NotNull(tContext.Client);
         }

--- a/tests/ElCamino.AspNetCore.Identity.AzureTable.Tests/ModelTests/IdentityCloudContextTests.cs
+++ b/tests/ElCamino.AspNetCore.Identity.AzureTable.Tests/ModelTests/IdentityCloudContextTests.cs
@@ -1,5 +1,6 @@
 ﻿// MIT License Copyright 2020 (c) David Melendez. All rights reserved. See License.txt in the project root for license information.
 using System;
+using Azure.Data.Tables;
 using ElCamino.AspNetCore.Identity.AzureTable.Helpers;
 using ElCamino.AspNetCore.Identity.AzureTable.Model;
 using ElCamino.Web.Identity.AzureTable.Tests.Fixtures;
@@ -26,9 +27,10 @@ namespace ElCamino.AspNetCore.Identity.AzureTable.Tests.ModelTests
             //Assert.Throws<ArgumentException>(() => new IdentityCloudContext(locConfig));
 
             //Coverage for FormatTableNameWithPrefix()
-            var tableConfig = roleFixture.GetConfig();
+            var tableConfig = roleFixture.GetConfig().config;
             tableConfig.TablePrefix = string.Empty;
-            var tContext = new IdentityCloudContext(tableConfig);
+            TableServiceClient client = new TableServiceClient(roleFixture.GetConfig().connectionString);
+            var tContext = new IdentityCloudContext(tableConfig, client);
 
             tableConfig.TablePrefix = "a";
             tContext = new IdentityCloudContext(tableConfig);

--- a/tests/ElCamino.AspNetCore.Identity.AzureTable.Tests/UserStoreSHA256Tests.cs
+++ b/tests/ElCamino.AspNetCore.Identity.AzureTable.Tests/UserStoreSHA256Tests.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Threading.Tasks;
+using Azure.Data.Tables;
 using ElCamino.AspNetCore.Identity.AzureTable.Helpers;
 using ElCamino.Web.Identity.AzureTable.Tests.Fixtures;
 using ElCamino.Web.Identity.AzureTable.Tests.ModelTests;
@@ -306,7 +307,7 @@ namespace ElCamino.AspNetCore.Identity.AzureTable.Tests
         private UserStore<ApplicationUserV2, IdentityRole, IdentityCloudContext> GetImmutableUserIdStore()
         {
             var config = userFixture.GetConfig();
-            var userStore = userFixture.CreateUserStore(userFixture.GetContext(config.config, new Azure.Data.Tables.TableServiceClient(config.connectionString)));
+            var userStore = userFixture.CreateUserStore(userFixture.GetContext(config.config, new TableServiceClient(config.connectionString)));
             return userStore;
         }
 

--- a/tests/ElCamino.AspNetCore.Identity.AzureTable.Tests/UserStoreSHA256Tests.cs
+++ b/tests/ElCamino.AspNetCore.Identity.AzureTable.Tests/UserStoreSHA256Tests.cs
@@ -306,7 +306,7 @@ namespace ElCamino.AspNetCore.Identity.AzureTable.Tests
         private UserStore<ApplicationUserV2, IdentityRole, IdentityCloudContext> GetImmutableUserIdStore()
         {
             var config = userFixture.GetConfig();
-            var userStore = userFixture.CreateUserStore(userFixture.GetContext(config));
+            var userStore = userFixture.CreateUserStore(userFixture.GetContext(config.config, new Azure.Data.Tables.TableServiceClient(config.connectionString)));
             return userStore;
         }
 

--- a/tests/ElCamino.AspNetCore.Identity.AzureTable.Tests/UserStoreTests.cs
+++ b/tests/ElCamino.AspNetCore.Identity.AzureTable.Tests/UserStoreTests.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Threading.Tasks;
+using Azure.Data.Tables;
 using ElCamino.AspNetCore.Identity.AzureTable.Helpers;
 using ElCamino.Web.Identity.AzureTable.Tests.Fixtures;
 using ElCamino.Web.Identity.AzureTable.Tests.ModelTests;
@@ -305,7 +306,7 @@ namespace ElCamino.AspNetCore.Identity.AzureTable.Tests
         private UserStore<ApplicationUserV2, IdentityRole, IdentityCloudContext> GetImmutableUserIdStore()
         {
             var config = userFixture.GetConfig();
-            var userStore = userFixture.CreateUserStore(userFixture.GetContext(config.config, new Azure.Data.Tables.TableServiceClient(config.connectionString)));
+            var userStore = userFixture.CreateUserStore(userFixture.GetContext(config.config, new TableServiceClient(config.connectionString)));
             return userStore;
         }
 

--- a/tests/ElCamino.AspNetCore.Identity.AzureTable.Tests/UserStoreTests.cs
+++ b/tests/ElCamino.AspNetCore.Identity.AzureTable.Tests/UserStoreTests.cs
@@ -305,7 +305,7 @@ namespace ElCamino.AspNetCore.Identity.AzureTable.Tests
         private UserStore<ApplicationUserV2, IdentityRole, IdentityCloudContext> GetImmutableUserIdStore()
         {
             var config = userFixture.GetConfig();
-            var userStore = userFixture.CreateUserStore(userFixture.GetContext(config));
+            var userStore = userFixture.CreateUserStore(userFixture.GetContext(config.config, new Azure.Data.Tables.TableServiceClient(config.connectionString)));
             return userStore;
         }
 

--- a/tests/ElCamino.Azure.Data.Tables.Tests/ElCamino.Azure.Data.Tables.Tests.csproj
+++ b/tests/ElCamino.Azure.Data.Tables.Tests/ElCamino.Azure.Data.Tables.Tests.csproj
@@ -21,7 +21,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="6.0.1">
+    <PackageReference Include="coverlet.collector" Version="6.0.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
@@ -30,9 +30,9 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="9.0.*" />
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="9.0.*" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="9.0.*" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
-    <PackageReference Include="xunit" Version="2.7.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.7">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/tests/ElCamino.Azure.Data.Tables.Tests/ElCamino.Azure.Data.Tables.Tests.csproj
+++ b/tests/ElCamino.Azure.Data.Tables.Tests/ElCamino.Azure.Data.Tables.Tests.csproj
@@ -3,11 +3,11 @@
   <PropertyGroup>
     <Description>Testing</Description>
     <Authors>David Melendez</Authors>
-    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
-    <LangVersion>11.0</LangVersion>
+    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+    <LangVersion>13.0</LangVersion>
     <AssemblyName>ElCamino.Azure.Data.Tables.Tests</AssemblyName>
     <IsPackable>false</IsPackable>
-    <Version>8.0</Version>
+    <Version>9.0</Version>
     <Nullable>disable</Nullable>
     <DebugType>Full</DebugType>
 

--- a/tests/ElCamino.Azure.Data.Tables.Tests/ElCamino.Azure.Data.Tables.Tests.csproj
+++ b/tests/ElCamino.Azure.Data.Tables.Tests/ElCamino.Azure.Data.Tables.Tests.csproj
@@ -25,11 +25,11 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.*" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.*" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="9.0.*" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="9.0.*" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="9.0.*" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
     <PackageReference Include="xunit" Version="2.7.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.7">

--- a/tests/ElCamino.Azure.Data.Tables.Tests/TableClientTests.cs
+++ b/tests/ElCamino.Azure.Data.Tables.Tests/TableClientTests.cs
@@ -1,5 +1,6 @@
 ﻿// MIT License Copyright 2020 (c) David Melendez. All rights reserved. See License.txt in the project root for license information.
 using System;
+using System.Diagnostics;
 using System.Threading.Tasks;
 using Azure.Data.Tables;
 using Xunit;
@@ -113,6 +114,8 @@ namespace ElCamino.Azure.Data.Tables.Tests
         [Fact]
         public async Task ExecuteTableQueryTakeCount()
         {
+            var sw = new Stopwatch();
+
             //Create Table
             await SetupTableAsync();
             //Setup Entity
@@ -134,7 +137,11 @@ namespace ElCamino.Azure.Data.Tables.Tests
                     var entity = new TableEntity(partitionKey, rowKey);
                     batch.UpsertEntity(entity, TableUpdateMode.Replace);
                 }
+                sw.Start();
                 await batch.SubmitBatchAsync();
+                sw.Stop();
+                _output.WriteLine($"{nameof(batch.SubmitBatchAsync)}: {sw.Elapsed.Milliseconds} ms");
+
                 count = await _tableClient.QueryAsync<TableEntity>(filter: filterByPartitionKey).CountAsync();
                 _output.WriteLine("Entities found after batch create {0}", count);
             }

--- a/tests/ElCamino.Azure.Data.Tables.Tests/TableClientTests.cs
+++ b/tests/ElCamino.Azure.Data.Tables.Tests/TableClientTests.cs
@@ -122,7 +122,7 @@ namespace ElCamino.Azure.Data.Tables.Tests
             var partitionKey = "b-" + Guid.NewGuid().ToString("N");
             _output.WriteLine("PartitionKey {0}", partitionKey);
 
-            var filterByPartitionKey = TableQuery.GenerateFilterCondition(nameof(TableEntity.PartitionKey), QueryComparisons.Equal, partitionKey);
+            string filterByPartitionKey = TableQuery.GenerateFilterCondition(nameof(TableEntity.PartitionKey), QueryComparisons.Equal, partitionKey).ToString();
             var count = await _tableClient.QueryAsync<TableEntity>(filter: filterByPartitionKey).CountAsync();
             const int maxTestEntities = 1001;
             _output.WriteLine("Entities found {0}", count);
@@ -190,7 +190,7 @@ namespace ElCamino.Azure.Data.Tables.Tests
                 batch.DeleteEntity(te.PartitionKey, te.RowKey, te.ETag);
             }
             await batch.SubmitBatchAsync();
-            count = await _tableClient.QueryAsync<TableEntity>(filter: filterByPartitionKey).CountAsync();
+            count = await _tableClient.QueryAsync<TableEntity>(filter: filterByPartitionKey.ToString()).CountAsync();
             _output.WriteLine("Entities found after batch delete {0}", count);
             Assert.Equal(0, count);
 

--- a/tests/ElCamino.Azure.Data.Tables.Tests/TableQueryBuilderTests.cs
+++ b/tests/ElCamino.Azure.Data.Tables.Tests/TableQueryBuilderTests.cs
@@ -1,0 +1,166 @@
+﻿// MIT License Copyright 2020 (c) David Melendez. All rights reserved. See License.txt in the project root for license information.
+#if NET9_0_OR_GREATER
+
+using System;
+using System.Collections.Concurrent;
+using System.Diagnostics;
+using System.Threading.Tasks;
+using Azure.Data.Tables;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace ElCamino.Azure.Data.Tables.Tests
+{
+    public class TableQueryBuilderTests : BaseTest
+    {
+
+        public TableQueryBuilderTests(TableFixture tableFixture, ITestOutputHelper output) :
+            base(tableFixture, output)
+        { }
+
+        private async Task SetupTableAsync()
+        {
+            //Setup Create table
+            await _tableClient.CreateIfNotExistsAsync();
+            _output.WriteLine("Table created {0}", TableName);
+
+        }        
+
+        [Fact]
+        public async Task QueryBuilderNullPropertyString()
+        {
+            string propertyName = "newProperty1";
+
+            //Create Table
+            await SetupTableAsync();
+            //Setup Entity
+            var key = "b-" + Guid.NewGuid().ToString("N");
+            _output.WriteLine("PartitionKey {0}", key);
+            _output.WriteLine("RowKey {0}", key);
+            var entity = new TableEntity(key, key);
+            Assert.Equal(default, entity.ETag);
+            Assert.Equal(default, entity.Timestamp);
+
+            //Execute Add
+            var addedEntity = await _tableClient.AddEntityWithHeaderValuesAsync(entity);
+            Stopwatch sw = new Stopwatch();
+            sw.Start();
+            TableQueryBuilder queryBuilderNull = new TableQueryBuilder();
+            string filterNullBuilder = queryBuilderNull
+                .BeginGroup()
+                .AddFilter(new QueryCondition<string>(nameof(TableEntity.PartitionKey), QueryComparison.Equal, addedEntity.PartitionKey))
+                .CombineFilters(TableOperator.And)
+                .AddFilter(new QueryCondition<string>(nameof(TableEntity.RowKey), QueryComparison.Equal, addedEntity.RowKey))
+                .EndGroup()
+                .CombineFilters(TableOperator.And)
+                .AddFilter(new QueryCondition<string>(propertyName, QueryComparison.Equal, null))
+                .ToString();
+            sw.Stop();
+            _output.WriteLine($"{nameof(filterNullBuilder)}: {sw.Elapsed.TotalMilliseconds}ms");
+            _output.WriteLine($"{nameof(filterNullBuilder)}:{filterNullBuilder}");
+
+            sw.Restart();
+            //Execute isNull Query
+            string filterByPartitionKey = TableQuery.GenerateFilterCondition(nameof(TableEntity.PartitionKey), QueryComparisons.Equal, addedEntity.PartitionKey).ToString();
+            string filterByRowKey = TableQuery.GenerateFilterCondition(nameof(TableEntity.RowKey), QueryComparisons.Equal, addedEntity.PartitionKey).ToString();
+            string filterByNullProperty = TableQuery.GenerateFilterConditionForStringNull(propertyName, QueryComparisons.Equal).ToString();
+            string filterByNotNullProperty = TableQuery.GenerateFilterConditionForStringNull(propertyName, QueryComparisons.NotEqual).ToString();
+
+            string filterNull = TableQuery.CombineFilters(
+                                TableQuery.CombineFilters(filterByPartitionKey, TableOperators.And, filterByRowKey),
+                                TableOperators.And,
+                                filterByNullProperty).ToString();
+            sw.Stop();
+            _output.WriteLine($"{nameof(filterNull)}: {sw.Elapsed.TotalMilliseconds}ms");
+
+            string filterNotNull = TableQuery.CombineFilters(
+                    TableQuery.CombineFilters(filterByPartitionKey, TableOperators.And, filterByRowKey),
+                    TableOperators.And,
+                    filterByNotNullProperty).ToString();
+
+            _output.WriteLine($"{nameof(filterNull)}:{filterNull}");
+            _output.WriteLine($"{nameof(filterNotNull)}:{filterNotNull}");
+
+            //Assert
+            Assert.Equal(1, await _tableClient.QueryAsync<TableEntity>(filter: filterNullBuilder).CountAsync());
+            Assert.Equal(1, await _tableClient.QueryAsync<TableEntity>(filter: filterNull).CountAsync());
+            Assert.Equal(0, await _tableClient.QueryAsync<TableEntity>(filter: filterNotNull).CountAsync());
+
+            //Modify update
+            var updateEntity = new TableEntity(key, key)
+            {
+                { propertyName, propertyName }
+            };
+
+            await Task.Delay(1000); //wait 1 second for timestamp 
+
+            _ = await _tableClient.UpdateEntityWithHeaderValuesAsync(updateEntity, addedEntity.ETag);
+
+            //Assert
+            Assert.Equal(0, await _tableClient.QueryAsync<TableEntity>(filter: filterNull).CountAsync());
+            Assert.Equal(1, await _tableClient.QueryAsync<TableEntity>(filter: filterNotNull.ToString()).CountAsync());
+
+
+        }
+
+        //[Fact]
+        //public async Task QueryNullPropertyBool()
+        //{
+        //    string propertyName = "newProperty";
+
+        //    //Create Table
+        //    await SetupTableAsync();
+        //    //Setup Entity
+        //    var key = "a-" + Guid.NewGuid().ToString("N");
+        //    _output.WriteLine("PartitionKey {0}", key);
+        //    _output.WriteLine("RowKey {0}", key);
+        //    var entity = new TableEntity(key, key);
+        //    Assert.Equal(default, entity.ETag);
+        //    Assert.Equal(default, entity.Timestamp);
+
+        //    //Execute Add
+        //    var addedEntity = await _tableClient.AddEntityWithHeaderValuesAsync(entity);
+
+        //    //Execute isNull Query
+        //    string filterByPartitionKey = TableQuery.GenerateFilterCondition(nameof(TableEntity.PartitionKey), QueryComparisons.Equal, addedEntity.PartitionKey);
+        //    string filterByRowKey = TableQuery.GenerateFilterCondition(nameof(TableEntity.RowKey), QueryComparisons.Equal, addedEntity.PartitionKey);
+        //    string filterByNullProperty = TableQuery.GenerateFilterConditionForBoolNull(propertyName, QueryComparisons.Equal);
+        //    string filterByNotNullProperty = TableQuery.GenerateFilterConditionForBoolNull(propertyName, QueryComparisons.NotEqual);
+
+        //    string filterNull = TableQuery.CombineFilters(
+        //                        TableQuery.CombineFilters(filterByPartitionKey, TableOperators.And, filterByRowKey),
+        //                        TableOperators.And,
+        //                        filterByNullProperty);
+        //    string filterNotNull = TableQuery.CombineFilters(
+        //            TableQuery.CombineFilters(filterByPartitionKey, TableOperators.And, filterByRowKey),
+        //            TableOperators.And,
+        //            filterByNotNullProperty);
+
+        //    _output.WriteLine($"{nameof(filterNull)}:{filterNull}");
+        //    _output.WriteLine($"{nameof(filterNotNull)}:{filterNotNull}");
+
+        //    //Assert
+        //    Assert.Equal(1, await _tableClient.QueryAsync<TableEntity>(filter: filterNull).CountAsync());
+        //    Assert.Equal(0, await _tableClient.QueryAsync<TableEntity>(filter: filterNotNull).CountAsync());
+
+        //    //Modify update
+        //    var updateEntity = new TableEntity(key, key)
+        //    {
+        //        { propertyName, true }
+        //    };
+
+        //    await Task.Delay(1000); //wait 1 second for timestamp 
+
+        //    _ = await _tableClient.UpdateEntityWithHeaderValuesAsync(updateEntity, addedEntity.ETag);
+
+        //    //Assert
+        //    Assert.Equal(0, await _tableClient.QueryAsync<TableEntity>(filter: filterNull).CountAsync());
+        //    Assert.Equal(1, await _tableClient.QueryAsync<TableEntity>(filter: filterNotNull).CountAsync());
+
+
+        //}
+
+
+    }
+}
+#endif

--- a/tests/ElCamino.Azure.Data.Tables.Tests/TableQueryTests.cs
+++ b/tests/ElCamino.Azure.Data.Tables.Tests/TableQueryTests.cs
@@ -1,6 +1,6 @@
 ﻿// MIT License Copyright 2020 (c) David Melendez. All rights reserved. See License.txt in the project root for license information.
 using System;
-using System.Collections.Concurrent;
+using System.Diagnostics;
 using System.Threading.Tasks;
 using Azure.Data.Tables;
 using Xunit;
@@ -41,20 +41,24 @@ namespace ElCamino.Azure.Data.Tables.Tests
             //Execute Add
             var addedEntity = await _tableClient.AddEntityWithHeaderValuesAsync(entity);
 
+            Stopwatch sw = new Stopwatch();
+            sw.Start();
             //Execute isNull Query
-            string filterByPartitionKey = TableQuery.GenerateFilterCondition(nameof(TableEntity.PartitionKey), QueryComparisons.Equal, addedEntity.PartitionKey);
-            string filterByRowKey = TableQuery.GenerateFilterCondition(nameof(TableEntity.RowKey), QueryComparisons.Equal, addedEntity.PartitionKey);
-            string filterByNullProperty = TableQuery.GenerateFilterConditionForStringNull(propertyName, QueryComparisons.Equal);
-            string filterByNotNullProperty = TableQuery.GenerateFilterConditionForStringNull(propertyName, QueryComparisons.NotEqual);
+            var filterByPartitionKey = TableQuery.GenerateFilterCondition(nameof(TableEntity.PartitionKey), QueryComparisons.Equal, addedEntity.PartitionKey);
+            var filterByRowKey = TableQuery.GenerateFilterCondition(nameof(TableEntity.RowKey), QueryComparisons.Equal, addedEntity.PartitionKey);
+            var filterByNullProperty = TableQuery.GenerateFilterConditionForStringNull(propertyName, QueryComparisons.Equal);
+            var filterByNotNullProperty = TableQuery.GenerateFilterConditionForStringNull(propertyName, QueryComparisons.NotEqual);
 
-            string filterNull = TableQuery.CombineFilters(
+            var filterNull = TableQuery.CombineFilters(
                                 TableQuery.CombineFilters(filterByPartitionKey, TableOperators.And, filterByRowKey),
                                 TableOperators.And,
-                                filterByNullProperty);
-            string filterNotNull = TableQuery.CombineFilters(
+                                filterByNullProperty).ToString();
+            sw.Stop();
+            _output.WriteLine($"{nameof(filterNull)}: {sw.Elapsed.TotalMilliseconds}ms");
+            var filterNotNull = TableQuery.CombineFilters(
                     TableQuery.CombineFilters(filterByPartitionKey, TableOperators.And, filterByRowKey),
                     TableOperators.And,
-                    filterByNotNullProperty);
+                    filterByNotNullProperty).ToString();
 
             _output.WriteLine($"{nameof(filterNull)}:{filterNull}");
             _output.WriteLine($"{nameof(filterNotNull)}:{filterNotNull}");
@@ -99,19 +103,19 @@ namespace ElCamino.Azure.Data.Tables.Tests
             var addedEntity = await _tableClient.AddEntityWithHeaderValuesAsync(entity);
 
             //Execute isNull Query
-            string filterByPartitionKey = TableQuery.GenerateFilterCondition(nameof(TableEntity.PartitionKey), QueryComparisons.Equal, addedEntity.PartitionKey);
-            string filterByRowKey = TableQuery.GenerateFilterCondition(nameof(TableEntity.RowKey), QueryComparisons.Equal, addedEntity.PartitionKey);
-            string filterByNullProperty = TableQuery.GenerateFilterConditionForBoolNull(propertyName, QueryComparisons.Equal);
-            string filterByNotNullProperty = TableQuery.GenerateFilterConditionForBoolNull(propertyName, QueryComparisons.NotEqual);
+            var filterByPartitionKey = TableQuery.GenerateFilterCondition(nameof(TableEntity.PartitionKey), QueryComparisons.Equal, addedEntity.PartitionKey);
+            var filterByRowKey = TableQuery.GenerateFilterCondition(nameof(TableEntity.RowKey), QueryComparisons.Equal, addedEntity.PartitionKey);
+            var filterByNullProperty = TableQuery.GenerateFilterConditionForBoolNull(propertyName, QueryComparisons.Equal);
+            var filterByNotNullProperty = TableQuery.GenerateFilterConditionForBoolNull(propertyName, QueryComparisons.NotEqual);
 
-            string filterNull = TableQuery.CombineFilters(
+            var filterNull = TableQuery.CombineFilters(
                                 TableQuery.CombineFilters(filterByPartitionKey, TableOperators.And, filterByRowKey),
                                 TableOperators.And,
-                                filterByNullProperty);
-            string filterNotNull = TableQuery.CombineFilters(
+                                filterByNullProperty).ToString();
+            var filterNotNull = TableQuery.CombineFilters(
                     TableQuery.CombineFilters(filterByPartitionKey, TableOperators.And, filterByRowKey),
                     TableOperators.And,
-                    filterByNotNullProperty);
+                    filterByNotNullProperty).ToString();
 
             _output.WriteLine($"{nameof(filterNull)}:{filterNull}");
             _output.WriteLine($"{nameof(filterNotNull)}:{filterNotNull}");


### PR DESCRIPTION
This pull request includes several updates to configuration files, project files, and code files to support new .NET versions and improve code quality. The most important changes include updating target frameworks and package versions, modifying the `IKeyHelper` interface to use `ReadOnlySpan<char>`, and adding new coding conventions.

### Configuration and Project File Updates:
* Updated `.editorconfig` to include new C# coding conventions and preferences. [[1]](diffhunk://#diff-0947e2727d6bad8cd0ac4122f5314bb5b04e337393075bc4b5ef143b17fcbd5bR68-R71) [[2]](diffhunk://#diff-0947e2727d6bad8cd0ac4122f5314bb5b04e337393075bc4b5ef143b17fcbd5bR138-R146)
* Updated `azure-pipelines.yml` to use newer .NET SDK versions (8.x and 9.x).
* Updated target frameworks and language versions in project files `ElCamino.AspNetCore.Identity.AzureTable.Model.csproj` and `ElCamino.AspNetCore.Identity.AzureTable.csproj` to support .NET 9.0. [[1]](diffhunk://#diff-550da455c750e1853c9980ed054f82acde80b61700979d1bd97973eeb1df80b5L8-R9) [[2]](diffhunk://#diff-550da455c750e1853c9980ed054f82acde80b61700979d1bd97973eeb1df80b5L25-R25) [[3]](diffhunk://#diff-550da455c750e1853c9980ed054f82acde80b61700979d1bd97973eeb1df80b5L39-R44) [[4]](diffhunk://#diff-6a9917daafd90ad160b30a4f10a1e55ae1e5767d851064ef5fa5c49206230c7dL8-R9) [[5]](diffhunk://#diff-6a9917daafd90ad160b30a4f10a1e55ae1e5767d851064ef5fa5c49206230c7dL24-R24) [[6]](diffhunk://#diff-6a9917daafd90ad160b30a4f10a1e55ae1e5767d851064ef5fa5c49206230c7dL41-R50)

### Interface and Method Changes:
* Breaking change Support for netstandard has been removed and .net 8 & 9 are currently supported.
* Breaking changes `IdentityBuilder.AddAzureTableStores` now requires a `TableServiceClient` to be included in DI, eliminating the need for the storage connection string in the `IdentityConfiguration'.
* Breaking changes `TableQuery` query filter to use `ReadOnlySpan<char>` instead of `string` and gained almost 10x improvement in emitting odata query filters.
* Fixed token update bugs #113 #104 not setting the value correctly
* Modified `IKeyHelper` interface methods to return `ReadOnlySpan<char>` instead of `string`.
* Updated `IdentityRole`, `IdentityRoleClaim`, `IdentityUser`, `IdentityUserClaim`, `IdentityUserLogin`, `IdentityUserRole`, and `IdentityUserToken` classes to convert `ReadOnlySpan<char>` to `string` where necessary. [[1]](diffhunk://#diff-697d69a62d6a7d4e97b9133dce65f04590fb7fb15533b82193d21526ded98380L23-R23) [[2]](diffhunk://#diff-697d69a62d6a7d4e97b9133dce65f04590fb7fb15533b82193d21526ded98380L33-R33) [[3]](diffhunk://#diff-8ee927d5e34910e59a06070033c6cb1a49c501d93007d7578c4716a77332644fL34-R34) [[4]](diffhunk://#diff-701a3cf0ed893685e6f6fed20f0e752106389de6cbfa92561b1cac859e64a896L33-R33) [[5]](diffhunk://#diff-701a3cf0ed893685e6f6fed20f0e752106389de6cbfa92561b1cac859e64a896L47-R47) [[6]](diffhunk://#diff-783b17ed94084e4973b5935f4032865d11914a5c150633a751e4786adeef80d3L30-R30) [[7]](diffhunk://#diff-1bbce5a3db049d425becbbb5c2db34b1d708d685d6fe234df324eef0b52d06c7L35-R35) [[8]](diffhunk://#diff-55fa251615cbbe4316f4bf755d917ebc6a14606ce36787c20a088408081acc66L33-R33) [[9]](diffhunk://#diff-698862b981f62ab3dc3e251429c06a5b7e89dad1892839592b3497904c4f0f23L37-R37)

### Code Quality Improvements:
* Removed `StorageConnectionString` property from `IdentityConfiguration` class.
* Added `ReadOnlySpan<char>` `IKeyHelper.cs` and `TableQuery` query filter to support tighter memory management

These changes collectively enhance the project by ensuring compatibility with the latest .NET versions and improving code maintainability and performance.