### PR TITLE
remove RC, add templates readme, GA ready

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -37,13 +37,12 @@ steps:
   displayName: 'Use .NET 10 SDK'
   inputs:
     version: 10.0.x
-    includePreviewVersions: true
 
 - task: DotNetCoreCLI@2
   displayName: 'dotnet build'
   inputs:
     projects: '**/ElCamino.AspNetCore.Identity.AzureTable.sln'
-    arguments: '-c $(BuildConfiguration) -p:Version=$(buildNumberVersion)'
+    arguments: '-c $(BuildConfiguration) -p:Version=$(BuildVersion)'
 
 - task: DotNetCoreCLI@2
   inputs:

--- a/src/ElCamino.AspNetCore.Identity.AzureTable.Model/ElCamino.AspNetCore.Identity.AzureTable.Model.csproj
+++ b/src/ElCamino.AspNetCore.Identity.AzureTable.Model/ElCamino.AspNetCore.Identity.AzureTable.Model.csproj
@@ -5,9 +5,9 @@
     <Copyright>Copyright ©  David Melendez, MIT License</Copyright>
     <AssemblyTitle>Azure Table Storage Provider for ASP.NET Identity Core Models</AssemblyTitle>
     <Authors>David Melendez</Authors>
-	<TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
-	<LangVersion>14.0</LangVersion>
-	<AssemblyName>ElCamino.AspNetCore.Identity.AzureTable.Model</AssemblyName>
+	  <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
+	  <LangVersion>14.0</LangVersion>
+	  <AssemblyName>ElCamino.AspNetCore.Identity.AzureTable.Model</AssemblyName>
     <AssemblyOriginatorKeyFile>../../tools/key.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
     <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
@@ -38,7 +38,7 @@
     <PackageReference Include="Azure.Data.Tables" Version="12.8.1" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net10.0' ">
-    <PackageReference Include="Microsoft.Extensions.Identity.Stores" Version="10.0.0-rc*" />
+    <PackageReference Include="Microsoft.Extensions.Identity.Stores" Version="10.0.*" />
   </ItemGroup>
 
 	<ItemGroup Condition=" '$(TargetFramework)' == 'net9.0' ">

--- a/src/ElCamino.AspNetCore.Identity.AzureTable/ElCamino.AspNetCore.Identity.AzureTable.csproj
+++ b/src/ElCamino.AspNetCore.Identity.AzureTable/ElCamino.AspNetCore.Identity.AzureTable.csproj
@@ -6,7 +6,7 @@
     <AssemblyTitle>Azure Table Storage Provider for ASP.NET Identity Core</AssemblyTitle>
     <Authors>David Melendez</Authors>
     <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
-	<LangVersion>14.0</LangVersion>
+	  <LangVersion>14.0</LangVersion>
     <AssemblyName>ElCamino.AspNetCore.Identity.AzureTable</AssemblyName>
     <AssemblyOriginatorKeyFile>../../tools/key.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
@@ -39,9 +39,9 @@
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net10.0' ">
-    <PackageReference Include="Microsoft.Extensions.Identity.Core" Version="10.0.0-rc*" />
-    <PackageReference Include="Microsoft.Extensions.Identity.Stores" Version="10.0.0-rc*" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.0-rc*" />
+    <PackageReference Include="Microsoft.Extensions.Identity.Core" Version="10.0.*" />
+    <PackageReference Include="Microsoft.Extensions.Identity.Stores" Version="10.0.*" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.*" />
   </ItemGroup>
 
     <ItemGroup Condition=" '$(TargetFramework)' == 'net9.0' ">

--- a/templates/ElCamino.AspNetCore.Identity.AzureTable.Templates.csproj
+++ b/templates/ElCamino.AspNetCore.Identity.AzureTable.Templates.csproj
@@ -24,7 +24,7 @@
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
     <PackageReleaseNotes>Check https://github.com/dlmelendez/identityazuretable/releases for the latest release information.</PackageReleaseNotes>
-
+    <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
 
   <ItemGroup>
@@ -33,6 +33,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <None Include="README.md" Link="README.md">
+      <PackagePath>\</PackagePath>
+      <Pack>True</Pack>
+    </None>
     <None Include="../src/ElCamino.AspNetCore.Identity.AzureTable/projectNugetPic.png" Pack="true" PackagePath="\" />
   </ItemGroup>
 </Project>

--- a/templates/README.md
+++ b/templates/README.md
@@ -1,0 +1,9 @@
+ElCamino.AspNetCore.Identity.AzureTable.Templates
+==================
+
+This package provides the ASP.NET Identity Core project Razor and MVC templates for the ElCamino.AspNetCore.Identity.AzureTable package that uses Azure Table storage instead of the Entity Framework / MSSQL data provider.
+
+[![Build Status](https://dev.azure.com/elcamino/Azure%20OpenSource/_apis/build/status%2Fdlmelendez.identityazuretable?branchName=master)](https://dev.azure.com/elcamino/Azure%20OpenSource/_build/latest?definitionId=18&branchName=master)
+[![NuGet Version](https://img.shields.io/nuget/v/ElCamino.AspNetCore.Identity.AzureTable.Templates)](https://www.nuget.org/packages/ElCamino.AspNetCore.Identity.AzureTable.Templates/)
+
+Project site at https://elcamino.cloud/projects/docs/identityazuretable/.

--- a/templates/templates/StarterWebMvc-CSharp/samplemvccore.csproj
+++ b/templates/templates/StarterWebMvc-CSharp/samplemvccore.csproj
@@ -8,12 +8,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="ElCamino.AspNetCore.Identity.AzureTable" Version="10.0.0-rc.1*" />
-    <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="10.0.0-rc.1.25451.107" />
-    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="10.0.0-rc.1.25451.107" />
-    <PackageReference Include="Microsoft.AspNetCore.Identity.UI" Version="10.0.0-rc.1.25451.107" />
+    <PackageReference Include="ElCamino.AspNetCore.Identity.AzureTable" Version="10.0.*" />
+    <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="10.0.*" />
+    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="10.0.*" />
+    <PackageReference Include="Microsoft.AspNetCore.Identity.UI" Version="10.0.*" />
     <PackageReference Include="Microsoft.Extensions.Azure" Version="1.11.0" />
-    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="10.0.0-rc.1.25458.5" />
+    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="10.0.*" />
   </ItemGroup>
 
   <Target Name="PreBuildDotnetToolsRestore" BeforeTargets="PreBuildEvent">

--- a/templates/templates/StarterWebRazorPages-CSharp/samplerazorpagescore.csproj
+++ b/templates/templates/StarterWebRazorPages-CSharp/samplerazorpagescore.csproj
@@ -8,12 +8,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="ElCamino.AspNetCore.Identity.AzureTable" Version="10.0.0-rc.1*" />
-    <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="10.0.0-rc.1.25451.107" />
-    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="10.0.0-rc.1.25451.107" />
-    <PackageReference Include="Microsoft.AspNetCore.Identity.UI" Version="10.0.0-rc.1.25451.107" />
+    <PackageReference Include="ElCamino.AspNetCore.Identity.AzureTable" Version="10.0.*" />
+    <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="10.0.*" />
+    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="10.0.*" />
+    <PackageReference Include="Microsoft.AspNetCore.Identity.UI" Version="10.0.*" />
     <PackageReference Include="Microsoft.Extensions.Azure" Version="1.11.0" />
-    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="10.0.0-rc.1.25458.5" />
+    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="10.0.*" />
   </ItemGroup>
 
   <Target Name="PreBuildDotnetToolsRestore" BeforeTargets="PreBuildEvent">

--- a/tests/ElCamino.AspNetCore.Identity.AzureTable.Tests/ElCamino.AspNetCore.Identity.AzureTable.Tests.csproj
+++ b/tests/ElCamino.AspNetCore.Identity.AzureTable.Tests/ElCamino.AspNetCore.Identity.AzureTable.Tests.csproj
@@ -32,21 +32,13 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.Identity.Core" Version="10.0.0-rc*" />
-    <PackageReference Include="Microsoft.Extensions.Identity.Stores" Version="10.0.0-rc*" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.0-rc*" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.0-rc*" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.0-rc*" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.0-rc*" />
-    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.0-rc*" />
-    <PackageReference Include="Microsoft.AspNetCore.DataProtection" Version="10.0.0-rc*" />
+
   </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="Azure.Data.Tables" Version="12.8.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
     <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="System.Diagnostics.TraceSource" Version="4.3.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/tests/ElCamino.Azure.Data.Tables.Tests/ElCamino.Azure.Data.Tables.Tests.csproj
+++ b/tests/ElCamino.Azure.Data.Tables.Tests/ElCamino.Azure.Data.Tables.Tests.csproj
@@ -25,12 +25,12 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.0-rc*" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.0-rc*" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.0-rc*" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.0-rc*" />
-    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.0-rc*" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.*" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.*" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.*" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.*" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.*" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
This pull request updates the project to target stable .NET 10 and associated package versions, replacing previous release candidate (`-rc*`) dependencies with wildcard stable versions (`10.0.*`). It also improves packaging for the templates project by including a `README.md` file and updates build and test configurations for consistency and compatibility.

**.NET 10 and Package Version Updates:**

* Updated all `PackageReference` entries in `.csproj` files to use stable `10.0.*` versions instead of release candidate (`-rc*`) versions for core dependencies, including `Microsoft.Extensions.Identity.Core`, `Microsoft.Extensions.Identity.Stores`, `Microsoft.Extensions.DependencyInjection`, and related ASP.NET Identity packages. This affects both main library, model, template, and test projects. [[1]](diffhunk://#diff-550da455c750e1853c9980ed054f82acde80b61700979d1bd97973eeb1df80b5L41-R41) [[2]](diffhunk://#diff-6a9917daafd90ad160b30a4f10a1e55ae1e5767d851064ef5fa5c49206230c7dL42-R44) [[3]](diffhunk://#diff-dad73c309a921ecdc069999d79ab40c9f4b09590fa6b198bda4514672acea730L28-R33) [[4]](diffhunk://#diff-f4c0bbfe552895732ca4317b497d7a41bb8fe1990a2574cccda9b42a34cb725eL11-R16) [[5]](diffhunk://#diff-aa3d18817b209991686b32b5c548d1477839d54f73519b906b2326292c04aa07L11-R16)

* Updated the Azure Pipelines build script to use the `BuildVersion` variable instead of `buildNumberVersion`, aligning with the new versioning approach for .NET 10.

**Template Packaging Improvements:**

* Added `PackageReadmeFile` property and included `README.md` in the package output for `ElCamino.AspNetCore.Identity.AzureTable.Templates`, ensuring NuGet consumers see documentation. [[1]](diffhunk://#diff-e03e23e6fec3209e0ba0223a2c5dc3b14e1e3eba75868cf277da97c7f50b3ce9L27-R27) [[2]](diffhunk://#diff-e03e23e6fec3209e0ba0223a2c5dc3b14e1e3eba75868cf277da97c7f50b3ce9R36-R39) [[3]](diffhunk://#diff-af03ff89b349afdbf776d0d586c7d37ce78adeaf36f3340d9a429d5cbb5de860R1-R9)
* Resolving #133

**Test Project Updates:**

* Updated test dependencies to use stable `10.0.*` versions and upgraded `Microsoft.NET.Test.Sdk` from `17.14.1` to `18.0.1` for better test compatibility and features. (Ff599170L39R39, [tests/ElCamino.Azure.Data.Tables.Tests/ElCamino.Azure.Data.Tables.Tests.csprojL28-R33](diffhunk://#diff-dad73c309a921ecdc069999d79ab40c9f4b09590fa6b198bda4514672acea730L28-R33))

These changes collectively modernize the codebase for .NET 10, improve package management and documentation, and ensure consistent dependency usage across all projects.